### PR TITLE
chore(deps): remediate safe Dependabot CVEs (npm audit fix + yaml override)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1948,16 +1948,6 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
-    "node_modules/@angular/build/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/@angular/cdk": {
       "version": "21.2.14",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.14.tgz",
@@ -5170,10 +5160,20 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7061,9 +7061,9 @@
       }
     },
     "node_modules/@microsoft/tsdoc": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
-      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
       "license": "MIT"
     },
     "node_modules/@mikro-orm/cli": {
@@ -7391,12 +7391,12 @@
       }
     },
     "node_modules/@module-federation/bridge-react-webpack-plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.4.0.tgz",
-      "integrity": "sha512-yxDv/FJoLiKo2eqIcEWvSnSpJgyYkCzJvNaFsQ2QE3rNv68IeAarlSzCo+d0QyQoPJnTETyHsOh1SSBazIzecw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/bridge-react-webpack-plugin/-/bridge-react-webpack-plugin-2.6.0.tgz",
+      "integrity": "sha512-V+4+1PUmDgAozXPJA8evIa2G+dPJGYn1JzDoHS9wMFch2blko/DO2sMq6FGuZFnT1oyjxiWeiaWXluRElOU9rQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.4.0",
+        "@module-federation/sdk": "2.6.0",
         "@types/semver": "7.5.8",
         "semver": "7.6.3"
       }
@@ -7414,13 +7414,13 @@
       }
     },
     "node_modules/@module-federation/cli": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.4.0.tgz",
-      "integrity": "sha512-c46g9srroc2hDfrlHyd4Y404SLnw3v9t7Kqij+yK01Hx8C2FyZpyanTGUHVyrmzqp/0y3lPrWURUHkHfk/cJQA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/cli/-/cli-2.6.0.tgz",
+      "integrity": "sha512-CHBsi5f8Oe9sCN6rY4R0+P/oFApvuutnqfoYNtuORdMn6FHittFDkuLFCSYlrZN2QYw/Sqir2xgLcwmY77Z7PA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
+        "@module-federation/dts-plugin": "2.6.0",
+        "@module-federation/sdk": "2.6.0",
         "commander": "11.1.0",
         "jiti": "2.4.2"
       },
@@ -7432,21 +7432,21 @@
       }
     },
     "node_modules/@module-federation/dts-plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.4.0.tgz",
-      "integrity": "sha512-sa6v5ByyqMRHzpwDu0zc7s5mZ39EFIkG0jkRfZU09pzkrJEIy4uZ1Kt9SLysFB8RBMIAvAakAfqDlVWvf1lndg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/dts-plugin/-/dts-plugin-2.6.0.tgz",
+      "integrity": "sha512-0dMjLhU+2HNPyX5Txu6JqA2CAYxVLRv3c/bpRk58aNVwhDO/jqp66IdFztdMZ1XiHqOW9jB3pkOSuIpcl/yXpQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/managers": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
-        "@module-federation/third-party-dts-extractor": "2.4.0",
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/managers": "2.6.0",
+        "@module-federation/sdk": "2.6.0",
+        "@module-federation/third-party-dts-extractor": "2.6.0",
         "adm-zip": "0.5.10",
         "ansi-colors": "4.1.3",
         "isomorphic-ws": "5.0.0",
         "node-schedule": "2.1.1",
-        "undici": "7.24.7",
-        "ws": "8.18.0"
+        "undici": "7.28.0",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": "^4.9.0 || ^5.0.0",
@@ -7459,22 +7459,22 @@
       }
     },
     "node_modules/@module-federation/enhanced": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.4.0.tgz",
-      "integrity": "sha512-NiccK03x7V6bK2LvJNuW520kT+Onx+LJe8lyPsENjXctECCIFJdJOmYr8ABif/kLayWKrrYCzCGVNNiQXANEGQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/enhanced/-/enhanced-2.6.0.tgz",
+      "integrity": "sha512-pQ0V93FfeHtr67Nusr6ySTQO1qeOGs1x9MMjbeZ4ObOPbXdHNX1tH19xVP8mo5k3e8iIV2teMoSayTmHT+nD0g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.4.0",
-        "@module-federation/cli": "2.4.0",
-        "@module-federation/dts-plugin": "2.4.0",
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/inject-external-runtime-core-plugin": "2.4.0",
-        "@module-federation/managers": "2.4.0",
-        "@module-federation/manifest": "2.4.0",
-        "@module-federation/rspack": "2.4.0",
-        "@module-federation/runtime-tools": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
-        "@module-federation/webpack-bundler-runtime": "2.4.0",
+        "@module-federation/bridge-react-webpack-plugin": "2.6.0",
+        "@module-federation/cli": "2.6.0",
+        "@module-federation/dts-plugin": "2.6.0",
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/inject-external-runtime-core-plugin": "2.6.0",
+        "@module-federation/managers": "2.6.0",
+        "@module-federation/manifest": "2.6.0",
+        "@module-federation/rspack": "2.6.0",
+        "@module-federation/runtime-tools": "2.6.0",
+        "@module-federation/sdk": "2.6.0",
+        "@module-federation/webpack-bundler-runtime": "2.6.0",
         "schema-utils": "4.3.0",
         "tapable": "2.3.0",
         "upath": "2.0.1"
@@ -7500,51 +7500,51 @@
       }
     },
     "node_modules/@module-federation/error-codes": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.4.0.tgz",
-      "integrity": "sha512-ktCZtwOoiKR1URJyBt223OsOFAUvc13rICYif55mt7+DomtELlh5FicnEz6mPLBUwmNM9vyBMvkxOdp+fQ5oUg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-2.6.0.tgz",
+      "integrity": "sha512-J9opjWJJZ1JI/9EvNZF8Ps1VMHS9EsH/i0UjCkQQxFVYZxSDBX1CFunvc7awac4cY//LqJUfqBbfoQPhCfKKKw==",
       "license": "MIT"
     },
     "node_modules/@module-federation/inject-external-runtime-core-plugin": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.4.0.tgz",
-      "integrity": "sha512-GucUMQmQXcnJC/OnJGvMz3Qy7ap8nAffhQPwDpOSi0Qwm+Iq/ppzG8N3tlLBDmv/O8hiF8HHlg789XK2kcCQtg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/inject-external-runtime-core-plugin/-/inject-external-runtime-core-plugin-2.6.0.tgz",
+      "integrity": "sha512-x5SmH33U1nSEcBXG6YzvkwIQLoKcd/CNfrAx4IJ4qBzlQKI0NvY7U4JE83LpBnwahNTQLvp27ZVX+1f7kt4Vww==",
       "license": "MIT",
       "peerDependencies": {
-        "@module-federation/runtime-tools": "2.4.0"
+        "@module-federation/runtime-tools": "2.6.0"
       }
     },
     "node_modules/@module-federation/managers": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.4.0.tgz",
-      "integrity": "sha512-Z8j6aog44G1gt4yIAaeDowwZ7xg0aAxTA1Hq69euJK9cR9MDEaLbLUk57jDoiRj6xLwlCiw7ozY+U15BQATk6Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/managers/-/managers-2.6.0.tgz",
+      "integrity": "sha512-7Y4Ri6Lh10dCHoEJvNGFmK2Gg1JKy7oJ1TEZhuU3n3mgIpZ519fDNRvU4+tiO9C49p1xyK+mQ8ewxth83waKUA==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/sdk": "2.4.0",
+        "@module-federation/sdk": "2.6.0",
         "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/manifest": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.4.0.tgz",
-      "integrity": "sha512-ZL+W5rbtgRf9TWRP7Dupt/Svia4bJEOS6gWSj9jzemiLPRPkMO5hjWZKVHIc8oG+Vb25yzozFMmQ+luGi695wg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/manifest/-/manifest-2.6.0.tgz",
+      "integrity": "sha512-wIjI4wgFKBoq4l/iBOT2lva+i5sPv1+Ci1gOLOfjMAkygyGo97csUG5TaCWgLJpZzbYrpbFObCB2wZhqaLrQIw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/dts-plugin": "2.4.0",
-        "@module-federation/managers": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
+        "@module-federation/dts-plugin": "2.6.0",
+        "@module-federation/managers": "2.6.0",
+        "@module-federation/sdk": "2.6.0",
         "find-pkg": "2.0.0"
       }
     },
     "node_modules/@module-federation/node": {
-      "version": "2.7.42",
-      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.42.tgz",
-      "integrity": "sha512-aX/T4L9bPbOgNLIW+30k/dA2Iohoy9/jf4yG1ka6Hkuo5h7iEBeZiQkwIqC06cnCbtKL1HnAiYlXHmrDPW5xvg==",
+      "version": "2.7.45",
+      "resolved": "https://registry.npmjs.org/@module-federation/node/-/node-2.7.45.tgz",
+      "integrity": "sha512-h9/jKp+gAGiO+gF4QOrzGDBVZVy+kfN+S06Pywbnpvpwe3DVMuhRXw9lcvZUDe23DHW0D/rAzaLrgNyq2qWciw==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/enhanced": "2.4.0",
-        "@module-federation/runtime": "2.4.0",
-        "@module-federation/sdk": "2.4.0",
+        "@module-federation/enhanced": "2.6.0",
+        "@module-federation/runtime": "2.6.0",
+        "@module-federation/sdk": "2.6.0",
         "encoding": "0.1.13",
         "node-fetch": "2.7.0",
         "tapable": "2.3.0"
@@ -7559,18 +7559,18 @@
       }
     },
     "node_modules/@module-federation/rspack": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.4.0.tgz",
-      "integrity": "sha512-NWH5Vaj/fA9R7PfbwTuE1Ty/pfiAt12On0E3FzoeVPCyb5MxO1i0z+xxRHbPhF4ZOrAPGEMaMQ8Z9vH94EiElw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/rspack/-/rspack-2.6.0.tgz",
+      "integrity": "sha512-Ayh7WLxhLRMyfBfajDwEytR5StFfnqf8p4tPHq5ds+HzJMlGz/M+NIYEzdOpfOFdE5IqN9bY/mj2AFI5lCureQ==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/bridge-react-webpack-plugin": "2.4.0",
-        "@module-federation/dts-plugin": "2.4.0",
-        "@module-federation/inject-external-runtime-core-plugin": "2.4.0",
-        "@module-federation/managers": "2.4.0",
-        "@module-federation/manifest": "2.4.0",
-        "@module-federation/runtime-tools": "2.4.0",
-        "@module-federation/sdk": "2.4.0"
+        "@module-federation/bridge-react-webpack-plugin": "2.6.0",
+        "@module-federation/dts-plugin": "2.6.0",
+        "@module-federation/inject-external-runtime-core-plugin": "2.6.0",
+        "@module-federation/managers": "2.6.0",
+        "@module-federation/manifest": "2.6.0",
+        "@module-federation/runtime-tools": "2.6.0",
+        "@module-federation/sdk": "2.6.0"
       },
       "peerDependencies": {
         "@rspack/core": "^0.7.0 || ^1.0.0 || ^2.0.0-0",
@@ -7587,40 +7587,40 @@
       }
     },
     "node_modules/@module-federation/runtime": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.4.0.tgz",
-      "integrity": "sha512-IrLAMwUuteRgFlEkg9jrn4bk8uC897FnXvfNmkKD8/qIoNtSd+32e5ouQn+PEYbX/RjRUB1TYveY6rYHpTPkyg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-2.6.0.tgz",
+      "integrity": "sha512-Y8KgL70RDxD8cCtGWGlGkt+TSDleIjdGmS27gnllibQAIgG/vHhPD11r8kd92x44k4dqtMIntzreOphGICl92g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/runtime-core": "2.4.0",
-        "@module-federation/sdk": "2.4.0"
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/runtime-core": "2.6.0",
+        "@module-federation/sdk": "2.6.0"
       }
     },
     "node_modules/@module-federation/runtime-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.4.0.tgz",
-      "integrity": "sha512-0S8fDw28DXDW17lTQwq5vfJWe2lG0Lw3+w4vk3DVVImLwXXay+OGxLDxzWUfypWcMznfpnoAnFUMO3PtuXziuA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-2.6.0.tgz",
+      "integrity": "sha512-9sL7Yj3H3COZI9JpK/J4hmJUBkIJdmowkj6phHuFiy5Hm5bHiE5U+9WBbR9KqTdyNhAVSL9FeprBW5/Io6i59A==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/sdk": "2.4.0"
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/sdk": "2.6.0"
       }
     },
     "node_modules/@module-federation/runtime-tools": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.4.0.tgz",
-      "integrity": "sha512-BWQsGT4EWscV9bx3bVHEwp6lERBsiYm7rnPiDpwd2fx+hGEpz1IM9Pz35VryHNDXYxw7MzaAuwTMM+L7uN8OYQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-2.6.0.tgz",
+      "integrity": "sha512-LfvihAhAWWNWlAL9zM+UDVDSSuLE2ZU0ATJ6dcbJuLstYbHYfUqq2e6IyU8TKLPXIib0VAWqPrT44TPam1VJ7g==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/runtime": "2.4.0",
-        "@module-federation/webpack-bundler-runtime": "2.4.0"
+        "@module-federation/runtime": "2.6.0",
+        "@module-federation/webpack-bundler-runtime": "2.6.0"
       }
     },
     "node_modules/@module-federation/sdk": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.4.0.tgz",
-      "integrity": "sha512-eZDdF5B69W9npuka0VL24FY7XDM+YAwwfkscSeWOSqv4/8Hm0xmcmSurlP6NIOrwbeogerRCtEcnx/TFXYjoow==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-2.6.0.tgz",
+      "integrity": "sha512-Z3HT1uDciMrvz2at3sw6TJbAK9Fl7RmoC/8iqO35HDtQMQJ1qSsMIAjnsiCpAC0D4nAm6PIqgSqPWRO/WYgo0Q==",
       "license": "MIT",
       "peerDependencies": {
         "node-fetch": "^2.7.0 || ^3.3.2"
@@ -7632,9 +7632,9 @@
       }
     },
     "node_modules/@module-federation/third-party-dts-extractor": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.4.0.tgz",
-      "integrity": "sha512-4v24t6L3dET/6abMOM2fiM3roT0c8mi21/i+uDc6WG7U0i+Xp2SojBppTs6gnT0lkwMTe+u6xIpNQakdUftHsg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/third-party-dts-extractor/-/third-party-dts-extractor-2.6.0.tgz",
+      "integrity": "sha512-rEC1YRC3gTafoOcFm1Htz6cAwHRoWEMQNCm1LXR1HiuayJzUkViVpK/1Pp37UZfytOyQ0qIaP6Ag81PdGvDbmw==",
       "license": "MIT",
       "dependencies": {
         "find-pkg": "2.0.0",
@@ -7642,14 +7642,14 @@
       }
     },
     "node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.4.0.tgz",
-      "integrity": "sha512-Ntx0+QsgcwtXlpGjL/Vf2PMdPjUHl07b3yM4kBc1kbRogW3Ee84QneBRi/X3w4/jlz4JKbHjD+CMXaqi2W6hgw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-2.6.0.tgz",
+      "integrity": "sha512-JjuWOU3ktwDjBWhM4WCoeiErcUxcB5YwUnVjyTMfNJHC3+DMhG4m6ziCl5EJrCv+KaEQdcvXmxLliNZidBZGQg==",
       "license": "MIT",
       "dependencies": {
-        "@module-federation/error-codes": "2.4.0",
-        "@module-federation/runtime": "2.4.0",
-        "@module-federation/sdk": "2.4.0"
+        "@module-federation/error-codes": "2.6.0",
+        "@module-federation/runtime": "2.6.0",
+        "@module-federation/sdk": "2.6.0"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -8199,6 +8199,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
@@ -8406,20 +8426,20 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.0.0.tgz",
-      "integrity": "sha512-sk2Mmf/hr75VM+HcHS62a/rGR+GX8g37VLK6Lr2dXM6r3pKJO1g++wOf2d1OOBBz3edDedgpK4A6mMp9ZC/j7Q==",
+      "version": "11.4.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.5.tgz",
+      "integrity": "sha512-lvndlJmWBVDOUT0uEtLi6sSpW1syK2/nbAlHBhiELBORMpJGe9+EiWAT9qHtB10jW91L2Jmlwkr0/lttsYZrig==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/tsdoc": "^0.15.0",
-        "@nestjs/mapped-types": "2.0.6",
-        "js-yaml": "4.1.0",
-        "lodash": "4.17.21",
-        "path-to-regexp": "^8.2.0",
-        "swagger-ui-dist": "5.18.2"
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.3.0",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.8"
       },
       "peerDependencies": {
-        "@fastify/static": "^8.0.0",
+        "@fastify/static": "^8.0.0 || ^9.0.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "class-transformer": "*",
@@ -8438,30 +8458,20 @@
         }
       }
     },
-    "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.6.tgz",
-      "integrity": "sha512-84ze+CPfp1OWdpRi1/lOu59hOhTz38eVzJvRKrg9ykRFwDz+XleKfMsG0gUqNZYFa6v53XYzeD+xItt8uDW7NQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
-        "reflect-metadata": "^0.1.12 || ^0.2.0"
-      },
-      "peerDependenciesMeta": {
-        "class-transformer": {
-          "optional": true
-        },
-        "class-validator": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nestjs/swagger/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10156,78 +10166,6 @@
         "yargs-parser": "21.1.1"
       }
     },
-    "node_modules/@nx/nest/node_modules/@nx/workspace/node_modules/nx": {
-      "version": "21.6.11",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-21.6.11.tgz",
-      "integrity": "sha512-AAgJGhS+7xlsmZF6ArKX1vgONxf7IymUYZ1BxGXHVa5927rGfgKoMaPOgwwtvN0OL3o/QYaNGwlDfIzCvlpOLQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "0.2.4",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.2",
-        "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.12.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "3.1.0",
-        "cli-spinners": "2.6.1",
-        "cliui": "^8.0.1",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "enquirer": "~2.3.6",
-        "figures": "3.2.0",
-        "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
-        "ignore": "^5.0.4",
-        "jest-diff": "^30.0.2",
-        "jsonc-parser": "3.2.0",
-        "lines-and-columns": "2.0.3",
-        "minimatch": "9.0.3",
-        "node-machine-id": "1.1.12",
-        "npm-run-path": "^4.0.1",
-        "open": "^8.4.0",
-        "ora": "5.3.0",
-        "resolve.exports": "2.0.3",
-        "semver": "^7.5.3",
-        "string-width": "^4.2.3",
-        "tar-stream": "~2.2.0",
-        "tmp": "~0.2.1",
-        "tree-kill": "^1.2.2",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0",
-        "yaml": "^2.6.0",
-        "yargs": "^17.6.2",
-        "yargs-parser": "21.1.1"
-      },
-      "bin": {
-        "nx": "bin/nx.js",
-        "nx-cloud": "bin/nx-cloud.js"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "21.6.11",
-        "@nx/nx-darwin-x64": "21.6.11",
-        "@nx/nx-freebsd-x64": "21.6.11",
-        "@nx/nx-linux-arm-gnueabihf": "21.6.11",
-        "@nx/nx-linux-arm64-gnu": "21.6.11",
-        "@nx/nx-linux-arm64-musl": "21.6.11",
-        "@nx/nx-linux-x64-gnu": "21.6.11",
-        "@nx/nx-linux-x64-musl": "21.6.11",
-        "@nx/nx-win32-arm64-msvc": "21.6.11",
-        "@nx/nx-win32-x64-msvc": "21.6.11"
-      },
-      "peerDependencies": {
-        "@swc-node/register": "^1.8.0",
-        "@swc/core": "^1.3.85"
-      },
-      "peerDependenciesMeta": {
-        "@swc-node/register": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nx/nest/node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -10383,6 +10321,78 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/@nx/nest/node_modules/nx": {
+      "version": "21.6.11",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-21.6.11.tgz",
+      "integrity": "sha512-AAgJGhS+7xlsmZF6ArKX1vgONxf7IymUYZ1BxGXHVa5927rGfgKoMaPOgwwtvN0OL3o/QYaNGwlDfIzCvlpOLQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "0.2.4",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "@yarnpkg/parsers": "3.0.2",
+        "@zkochan/js-yaml": "0.0.7",
+        "axios": "^1.12.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "^8.0.1",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "enquirer": "~2.3.6",
+        "figures": "3.2.0",
+        "flat": "^5.0.2",
+        "front-matter": "^4.0.2",
+        "ignore": "^5.0.4",
+        "jest-diff": "^30.0.2",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "2.0.3",
+        "minimatch": "9.0.3",
+        "node-machine-id": "1.1.12",
+        "npm-run-path": "^4.0.1",
+        "open": "^8.4.0",
+        "ora": "5.3.0",
+        "resolve.exports": "2.0.3",
+        "semver": "^7.5.3",
+        "string-width": "^4.2.3",
+        "tar-stream": "~2.2.0",
+        "tmp": "~0.2.1",
+        "tree-kill": "^1.2.2",
+        "tsconfig-paths": "^4.1.2",
+        "tslib": "^2.3.0",
+        "yaml": "^2.6.0",
+        "yargs": "^17.6.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "bin/nx.js",
+        "nx-cloud": "bin/nx-cloud.js"
+      },
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "21.6.11",
+        "@nx/nx-darwin-x64": "21.6.11",
+        "@nx/nx-freebsd-x64": "21.6.11",
+        "@nx/nx-linux-arm-gnueabihf": "21.6.11",
+        "@nx/nx-linux-arm64-gnu": "21.6.11",
+        "@nx/nx-linux-arm64-musl": "21.6.11",
+        "@nx/nx-linux-x64-gnu": "21.6.11",
+        "@nx/nx-linux-x64-musl": "21.6.11",
+        "@nx/nx-win32-arm64-msvc": "21.6.11",
+        "@nx/nx-win32-x64-msvc": "21.6.11"
+      },
+      "peerDependencies": {
+        "@swc-node/register": "^1.8.0",
+        "@swc/core": "^1.3.85"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nx/nest/node_modules/open": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
@@ -10502,21 +10512,6 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@nx/nest/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@nx/nest/node_modules/yargs": {
@@ -10819,78 +10814,6 @@
         "yargs-parser": "21.1.1"
       }
     },
-    "node_modules/@nx/node/node_modules/@nx/workspace/node_modules/nx": {
-      "version": "21.6.11",
-      "resolved": "https://registry.npmjs.org/nx/-/nx-21.6.11.tgz",
-      "integrity": "sha512-AAgJGhS+7xlsmZF6ArKX1vgONxf7IymUYZ1BxGXHVa5927rGfgKoMaPOgwwtvN0OL3o/QYaNGwlDfIzCvlpOLQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "0.2.4",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "@yarnpkg/parsers": "3.0.2",
-        "@zkochan/js-yaml": "0.0.7",
-        "axios": "^1.12.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "3.1.0",
-        "cli-spinners": "2.6.1",
-        "cliui": "^8.0.1",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "enquirer": "~2.3.6",
-        "figures": "3.2.0",
-        "flat": "^5.0.2",
-        "front-matter": "^4.0.2",
-        "ignore": "^5.0.4",
-        "jest-diff": "^30.0.2",
-        "jsonc-parser": "3.2.0",
-        "lines-and-columns": "2.0.3",
-        "minimatch": "9.0.3",
-        "node-machine-id": "1.1.12",
-        "npm-run-path": "^4.0.1",
-        "open": "^8.4.0",
-        "ora": "5.3.0",
-        "resolve.exports": "2.0.3",
-        "semver": "^7.5.3",
-        "string-width": "^4.2.3",
-        "tar-stream": "~2.2.0",
-        "tmp": "~0.2.1",
-        "tree-kill": "^1.2.2",
-        "tsconfig-paths": "^4.1.2",
-        "tslib": "^2.3.0",
-        "yaml": "^2.6.0",
-        "yargs": "^17.6.2",
-        "yargs-parser": "21.1.1"
-      },
-      "bin": {
-        "nx": "bin/nx.js",
-        "nx-cloud": "bin/nx-cloud.js"
-      },
-      "optionalDependencies": {
-        "@nx/nx-darwin-arm64": "21.6.11",
-        "@nx/nx-darwin-x64": "21.6.11",
-        "@nx/nx-freebsd-x64": "21.6.11",
-        "@nx/nx-linux-arm-gnueabihf": "21.6.11",
-        "@nx/nx-linux-arm64-gnu": "21.6.11",
-        "@nx/nx-linux-arm64-musl": "21.6.11",
-        "@nx/nx-linux-x64-gnu": "21.6.11",
-        "@nx/nx-linux-x64-musl": "21.6.11",
-        "@nx/nx-win32-arm64-msvc": "21.6.11",
-        "@nx/nx-win32-x64-msvc": "21.6.11"
-      },
-      "peerDependencies": {
-        "@swc-node/register": "^1.8.0",
-        "@swc/core": "^1.3.85"
-      },
-      "peerDependenciesMeta": {
-        "@swc-node/register": {
-          "optional": true
-        },
-        "@swc/core": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nx/node/node_modules/@phenomnomnominal/tsquery": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-5.0.1.tgz",
@@ -11058,6 +10981,78 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/@nx/node/node_modules/nx": {
+      "version": "21.6.11",
+      "resolved": "https://registry.npmjs.org/nx/-/nx-21.6.11.tgz",
+      "integrity": "sha512-AAgJGhS+7xlsmZF6ArKX1vgONxf7IymUYZ1BxGXHVa5927rGfgKoMaPOgwwtvN0OL3o/QYaNGwlDfIzCvlpOLQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "0.2.4",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "@yarnpkg/parsers": "3.0.2",
+        "@zkochan/js-yaml": "0.0.7",
+        "axios": "^1.12.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "3.1.0",
+        "cli-spinners": "2.6.1",
+        "cliui": "^8.0.1",
+        "dotenv": "~16.4.5",
+        "dotenv-expand": "~11.0.6",
+        "enquirer": "~2.3.6",
+        "figures": "3.2.0",
+        "flat": "^5.0.2",
+        "front-matter": "^4.0.2",
+        "ignore": "^5.0.4",
+        "jest-diff": "^30.0.2",
+        "jsonc-parser": "3.2.0",
+        "lines-and-columns": "2.0.3",
+        "minimatch": "9.0.3",
+        "node-machine-id": "1.1.12",
+        "npm-run-path": "^4.0.1",
+        "open": "^8.4.0",
+        "ora": "5.3.0",
+        "resolve.exports": "2.0.3",
+        "semver": "^7.5.3",
+        "string-width": "^4.2.3",
+        "tar-stream": "~2.2.0",
+        "tmp": "~0.2.1",
+        "tree-kill": "^1.2.2",
+        "tsconfig-paths": "^4.1.2",
+        "tslib": "^2.3.0",
+        "yaml": "^2.6.0",
+        "yargs": "^17.6.2",
+        "yargs-parser": "21.1.1"
+      },
+      "bin": {
+        "nx": "bin/nx.js",
+        "nx-cloud": "bin/nx-cloud.js"
+      },
+      "optionalDependencies": {
+        "@nx/nx-darwin-arm64": "21.6.11",
+        "@nx/nx-darwin-x64": "21.6.11",
+        "@nx/nx-freebsd-x64": "21.6.11",
+        "@nx/nx-linux-arm-gnueabihf": "21.6.11",
+        "@nx/nx-linux-arm64-gnu": "21.6.11",
+        "@nx/nx-linux-arm64-musl": "21.6.11",
+        "@nx/nx-linux-x64-gnu": "21.6.11",
+        "@nx/nx-linux-x64-musl": "21.6.11",
+        "@nx/nx-win32-arm64-msvc": "21.6.11",
+        "@nx/nx-win32-x64-msvc": "21.6.11"
+      },
+      "peerDependencies": {
+        "@swc-node/register": "^1.8.0",
+        "@swc/core": "^1.3.85"
+      },
+      "peerDependenciesMeta": {
+        "@swc-node/register": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nx/node/node_modules/open": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
@@ -11177,21 +11172,6 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@nx/node/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@nx/node/node_modules/yargs": {
@@ -12113,9 +12093,19 @@
       }
     },
     "node_modules/@nx/webpack/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -14221,9 +14211,9 @@
       }
     },
     "node_modules/@rspack/dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
@@ -20878,22 +20868,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/docker-compose/node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/docker-modem": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
@@ -21627,10 +21601,20 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -22738,9 +22722,19 @@
       }
     },
     "node_modules/fork-ts-checker-webpack-plugin/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -25427,9 +25421,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -28266,18 +28260,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/nx/node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/nx/node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -29583,9 +29565,19 @@
       }
     },
     "node_modules/postcss-loader/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -32821,9 +32813,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
-      "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
+      "version": "5.32.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+      "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
@@ -34636,9 +34628,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -35463,9 +35455,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
@@ -36122,12 +36114,18 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "hono": "^4.12.27",
     "launch-editor": "^2.14.1",
     "@babel/core": "^7.29.1",
+    "yaml": "^2.8.3",
     "fast-xml-parser": "$fast-xml-parser",
     "uuid": "$uuid"
   },


### PR DESCRIPTION
## What

The safe, non-breaking slice of the open Dependabot alerts on `main`.

- `npm audit fix` (lockfile-only — no direct-dependency version changes).
- Added a `yaml` override (`^2.8.3`) — Nx pins `yaml` below the patched version,
  so `audit fix` can't reach it (GHSA-48c2-rrv3-qjmp, stack overflow on deeply
  nested YAML).

**Root `npm audit`: 39 → 29 vulnerable nodes** (cleared 7 high + 3 moderate).

## Why the rest isn't in here (triage)

The remaining alerts are **dev/build-toolchain transitives** — `minimatch`,
`picomatch`, `http-proxy-middleware`, `undici`, `esbuild`, and the `@nx/*` /
`@angular-devkit` internals — pulled in by the pinned **Angular 21 / Nx 22**
toolchain. They are **not** in the published `@openbucket/nestjs` runtime
dependency closure (its runtime deps — `@mikro-orm/*`, `@nestjs/*`, `argon2`,
etc. — are clean).

They can't be fixed mechanically:
- **Dependabot itself fails** on them: the only fix path "would downgrade
  `@angular-devkit/build-angular` from 21.2.18 to 20.3.31" (from the failed
  `Dependabot Updates` run).
- A blanket `override` on `minimatch`/`picomatch` to a new major would break
  `micromatch`.

Clearing them needs a coordinated **framework upgrade** (`nx migrate` 22→23 +
`ng update` for Angular) — a separate, well-validated effort.

`apps/docs` (a standalone Docusaurus lockfile, **not** Dependabot-monitored) is
left as-is; its findings need breaking `--force` updates.

## Verification (on the updated lockfile)

| Check | Result |
|---|---|
| nestjs unit suite | 529 passed / 3 skipped |
| backend build (webpack) | ✅ |
| Angular frontend build | ✅ |
| lint (nestjs + frontend + backend) | ✅ 0 errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)