### PR TITLE
fix(spa): serve admin assets root-relative so pnpm .pnpm paths don't 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ versions may include breaking changes.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **Admin SPA served 500 for every static asset under pnpm.** With
+  `admin.serveUi: true`, the bundled console's hashed assets (`main-*.js`,
+  `chunk-*.js`, `styles.css`, …) all failed under pnpm's default isolated layout.
+  Express 5's `res.sendFile(absolutePath)` delegates to `send@1.x`, whose default
+  `dotfiles: 'ignore'` rejects any path with a dot-prefixed segment — and pnpm
+  stores the package under a `.pnpm/` directory, so every absolute asset path
+  contained one. The SPA controller now serves root-relative
+  (`res.sendFile(relative(spaRoot, file), { root: spaRoot })`), which exempts the
+  root prefix from the dotfile check. npm/yarn's flat layout masked this.
 
 ## [0.1.0-alpha.2] — 2026-07-02
 

--- a/libs/nestjs/src/lib/spa/spa.controller.spec.ts
+++ b/libs/nestjs/src/lib/spa/spa.controller.spec.ts
@@ -1,6 +1,6 @@
 import { type INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import request from 'supertest';
@@ -73,6 +73,62 @@ describe('SpaController (fixture SPA, mountPath "")', () => {
 
   it('falls back to the shell for client-side routes', async () => {
     const res = await request(app.getHttpServer()).get('/admin/buckets/my-bucket');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('OPENBUCKET_SHELL');
+  });
+});
+
+// Regression (pnpm): under pnpm's default isolated layout the package's real
+// files live under a `.pnpm/` directory, so the resolved SPA root — and every
+// absolute asset path derived from it — contains a DOT-PREFIXED path segment.
+// Express 5's `res.sendFile(absolutePath)` delegates to `send@1.x`, whose default
+// `dotfiles: 'ignore'` 404s any path with a dot segment, turning every hashed
+// asset into an (empty-bodied) 500. Serving root-relative (`{ root: spaRoot }`)
+// exempts the root prefix from that check. A dot-free `tmpdir` fixture (the other
+// suites above) masks this entirely.
+describe('SpaController (pnpm `.pnpm`-store layout — dotfile-segment regression)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const base = mkdtempSync(join(tmpdir(), 'ob-spa-pnpm-'));
+    const root = join(
+      base,
+      '.pnpm',
+      '@openbucket+nestjs@0.0.0',
+      'node_modules',
+      '@openbucket',
+      'nestjs',
+      'assets',
+      'spa',
+    );
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'index.html'),
+      '<html><head><base href="/admin/"></head><body>OPENBUCKET_SHELL</body></html>',
+    );
+    writeFileSync(join(root, 'main-UZ7C7DZ3.js'), 'console.log("ob")');
+
+    const ref = await Test.createTestingModule({
+      controllers: [SpaController],
+      providers: [{ provide: SPA_ROOT, useValue: root }],
+    }).compile();
+    app = ref.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it('serves a hashed asset even when the SPA root contains a `.pnpm` segment', async () => {
+    const res = await request(app.getHttpServer()).get('/admin/main-UZ7C7DZ3.js');
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('console.log');
+    expect(res.headers['cache-control']).toContain('immutable');
+  });
+
+  it('still serves the shell under a `.pnpm` root', async () => {
+    const res = await request(app.getHttpServer()).get('/admin');
     expect(res.status).toBe(200);
     expect(res.text).toContain('OPENBUCKET_SHELL');
   });

--- a/libs/nestjs/src/lib/spa/spa.controller.ts
+++ b/libs/nestjs/src/lib/spa/spa.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Inject, Optional, Req, Res } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { readFileSync } from 'node:fs';
-import { extname } from 'node:path';
+import { extname, relative } from 'node:path';
 
 import { OPEN_BUCKET_OPTIONS, type ResolvedOpenBucketOptions } from '../open-bucket-options';
 import { Public } from '../common/auth/public.decorator';
@@ -43,7 +43,14 @@ export class SpaController {
       const file = safeAssetPath(this.spaRoot, rel);
       if (file) {
         res.setHeader('Cache-Control', cacheControlFor(file));
-        res.sendFile(file);
+        // Serve root-relative, NOT as an absolute path. Express 5's `res.sendFile`
+        // delegates to `send@1.x`, whose default `dotfiles: 'ignore'` rejects any
+        // path containing a dot-prefixed segment. Under pnpm the package's real
+        // files live under a `.pnpm/` store directory, so the absolute `file` has a
+        // dot segment and every asset 404s (surfacing as a 500). `send` exempts the
+        // `root` prefix from the dotfile check, and `safeAssetPath` has already
+        // validated `file` stays within `spaRoot`, so the relative remainder is safe.
+        res.sendFile(relative(this.spaRoot, file), { root: this.spaRoot });
         return;
       }
     }


### PR DESCRIPTION
## Problem

With `admin.serveUi: true`, the bundled admin console loaded its HTML shell but
**every** static asset (`main-*.js`, `chunk-*.js`, `polyfills.js`, `styles.css`,
`favicon.ico`) returned **500** — the console is unusable under **pnpm**.

## Root cause

Express 5's `res.sendFile(absolutePath)` delegates to `send@1.x`, whose default
`dotfiles: 'ignore'` returns a 404 (surfaced by the app's error layer as an
empty-bodied 500) for **any path containing a dot-prefixed segment**. Under
pnpm's default isolated layout the package's real files live under a `.pnpm/`
store directory:

```
…/node_modules/.pnpm/@openbucket+nestjs@…/node_modules/@openbucket/nestjs/assets/spa/main.js
               ^^^^^^ dot-prefixed segment → send refuses the file
```

`SpaController.serve` served the resolved **absolute** path, so every asset
tripped the filter. npm/yarn install flat (no `.pnpm/` segment), which is why it
was never caught — a genuine test-coverage gap.

## Fix

`libs/nestjs/src/lib/spa/spa.controller.ts` — serve **root-relative**:

```ts
res.sendFile(relative(this.spaRoot, file), { root: this.spaRoot }); // was: res.sendFile(file)
```

`send` exempts the `root` prefix from the dotfile check, and `safeAssetPath`
already validated the file stays within `spaRoot`, so the relative remainder is
safe and dot-free. (Preferred over `{ dotfiles: 'allow' }`, which would weaken
dotfile protection for the served subtree.)

## Test

Adds a regression suite that boots the controller with a **`.pnpm`-segmented**
SPA root and asserts the hashed asset serves **200**. It **fails against the old
absolute `sendFile`** (404) and passes with the fix — the existing suites used a
dot-free `tmpdir` fixture that masked the bug.

## Audit of other static-serve sites

- Standalone `apps/openbucket-backend/src/main.ts` serves assets via
  `express.static(spaRoot, …)` (root-based → already exempt) and an `index.html`
  fallback that isn't dot-affected in the Docker image. **Unaffected**; left as-is.

## Verification

- SPA spec: 9/9 (incl. new regression) · full nestjs unit suite: 531 passed / 3 skipped
- `nx build nestjs` (tsc) + `nx lint nestjs`: clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)