### PR TITLE
fix(admin): make the console work under a non-root mountPath (API URLs + cookie path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,20 @@ versions may include breaking changes.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **Admin console was unusable under a non-root `mountPath`** (e.g.
+  `mountPath: '/storage'`): every API call 404'd (`POST /api/admin/auth/login`,
+  `/refresh`, …) and, even once reachable, the session wouldn't persist. Two
+  causes, both now mount-aware:
+  - **Frontend** built every API/S3 URL root-absolute (`/api/admin/…`,
+    `/<bucket>/<key>`), ignoring the mount. A new HTTP interceptor derives the
+    mount prefix from the SPA's `<base href>` (which the backend rewrites to
+    `<mountPath>/admin/`) and prepends it to all `/api/*` requests; the object
+    "copy URL" share link is likewise prefixed. No-op for the standalone (root).
+  - **Backend** set the refresh cookie with a hardcoded `path=/api/admin/auth`,
+    so the browser never sent it to `<mountPath>/api/admin/auth/refresh`. The
+    cookie `path` (set + clear) now includes the mount prefix.
 
 ## [0.1.0-alpha.3] — 2026-07-02
 

--- a/apps/openbucket-frontend/src/app/app.config.ts
+++ b/apps/openbucket-frontend/src/app/app.config.ts
@@ -30,6 +30,7 @@ import { appRoutes } from './app.routes';
 import { authInterceptor } from './auth/auth.interceptor';
 import { AuthService } from './auth/auth.service';
 import { provideApiClient } from './shared/api/api-client.providers';
+import { mountPrefixInterceptor } from './shared/api/mount-prefix';
 import {
   CALENDAR_I18N_CONFIGS,
   ColorSchemeService,
@@ -67,7 +68,9 @@ export const appConfig: ApplicationConfig = {
     provideHlmDatePickerConfig(DATE_PICKER_CONFIGS['en']),
     provideHttpClient(
       withFetch(),
-      withInterceptors([authInterceptor]),
+      // authInterceptor FIRST (its auth-path check keys on the un-prefixed
+      // `/api/admin/auth/*` URL); mountPrefixInterceptor then prepends the mount.
+      withInterceptors([authInterceptor, mountPrefixInterceptor]),
       withInterceptorsFromDi(),
     ),
     provideApiClient(),

--- a/apps/openbucket-frontend/src/app/objects/object-browser.component.ts
+++ b/apps/openbucket-frontend/src/app/objects/object-browser.component.ts
@@ -47,6 +47,7 @@ import {
 } from '@openbucket/api-client';
 import { firstValueFrom } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
+import { resolveMountPrefix } from '../shared/api/mount-prefix';
 import { HlmTableImports } from '@openbucket/spartan-ui/table';
 import { HlmBadge } from '@openbucket/spartan-ui/badge';
 import { HlmButton } from '@openbucket/spartan-ui/button';
@@ -986,7 +987,9 @@ export class ObjectBrowserComponent implements OnInit {
   }
 
   async copyUrl(o: ObjectListItem): Promise<void> {
-    const url = `${window.location.origin}/${this.bucket()}/${o.key}`;
+    // Path-style S3 URL. The store is mounted under `<mountPath>` too, so the
+    // shareable URL must carry the same prefix (e.g. `<origin>/storage/<bucket>/<key>`).
+    const url = `${window.location.origin}${resolveMountPrefix()}/${this.bucket()}/${o.key}`;
     try {
       await navigator.clipboard.writeText(url);
       notify.success('URL copied');

--- a/apps/openbucket-frontend/src/app/shared/api/mount-prefix.spec.ts
+++ b/apps/openbucket-frontend/src/app/shared/api/mount-prefix.spec.ts
@@ -1,0 +1,75 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { mountPrefixInterceptor, resolveMountPrefix } from './mount-prefix';
+
+/**
+ * The admin console is served under `<mountPath>/admin`; the backend rewrites the
+ * `<base href>` to `<mountPath>/admin/`. All API URLs the SPA builds are otherwise
+ * root-absolute (`/api/admin/...`), so they 404 under any non-root mount. The
+ * interceptor prefixes them with the derived mount.
+ *
+ * NOTE: parked until the frontend jest harness is wired (see auth.interceptor.spec);
+ * the derivation + build are otherwise verified.
+ */
+describe('resolveMountPrefix', () => {
+  const doc = (href: string | null): Document =>
+    ({ querySelector: () => (href === null ? null : { getAttribute: () => href }) }) as never;
+
+  it('derives the mount prefix from <base href>', () => {
+    expect(resolveMountPrefix(doc('/storage/admin/'))).toBe('/storage');
+    expect(resolveMountPrefix(doc('/deep/mount/admin/'))).toBe('/deep/mount');
+  });
+
+  it('is empty for the standalone root (/admin/) and when no base is present', () => {
+    expect(resolveMountPrefix(doc('/admin/'))).toBe('');
+    expect(resolveMountPrefix(doc(null))).toBe('');
+  });
+});
+
+describe('mountPrefixInterceptor', () => {
+  let http: HttpClient;
+  let ctrl: HttpTestingController;
+
+  const withBaseHref = (href: string) => {
+    document.head.querySelectorAll('base').forEach((b) => b.remove());
+    const base = document.createElement('base');
+    base.setAttribute('href', href);
+    document.head.appendChild(base);
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([mountPrefixInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+    http = TestBed.inject(HttpClient);
+    ctrl = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    ctrl.verify();
+    document.head.querySelectorAll('base').forEach((b) => b.remove());
+  });
+
+  it('prefixes /api/* calls with the mount when mounted', () => {
+    withBaseHref('/storage/admin/');
+    http.post('/api/admin/auth/login', {}).subscribe();
+    ctrl.expectOne('/storage/api/admin/auth/login').flush({});
+  });
+
+  it('leaves /api/* calls untouched for the standalone root', () => {
+    withBaseHref('/admin/');
+    http.get('/api/admin/buckets').subscribe();
+    ctrl.expectOne('/api/admin/buckets').flush({});
+  });
+
+  it('never rewrites non-/api URLs', () => {
+    withBaseHref('/storage/admin/');
+    http.get('/my-bucket/photo.jpg').subscribe();
+    ctrl.expectOne('/my-bucket/photo.jpg').flush({});
+  });
+});

--- a/apps/openbucket-frontend/src/app/shared/api/mount-prefix.ts
+++ b/apps/openbucket-frontend/src/app/shared/api/mount-prefix.ts
@@ -1,0 +1,37 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+
+/**
+ * The SPA's mount prefix, derived from the document `<base href>`.
+ *
+ * The backend rewrites the base to `<mountPath>/admin/` at serve time (e.g.
+ * `/storage/admin/` when embedded under `mountPath: '/storage'`, or `/admin/`
+ * for the standalone app). Stripping the trailing `admin/` yields the mount
+ * prefix — `/storage` when mounted, `''` for the standalone root.
+ *
+ * Every API/S3 URL the SPA builds is otherwise root-absolute (`/api/admin/...`,
+ * `/<bucket>/<key>`), which only works at the root. Prefixing with this value
+ * makes the console work under any mount.
+ */
+export function resolveMountPrefix(doc: Document = document): string {
+  const href = doc.querySelector('base')?.getAttribute('href') ?? '/';
+  // "<mountPath>/admin/" → "<mountPath>"; "/admin/" → "".
+  return href.replace(/admin\/?$/, '').replace(/\/$/, '');
+}
+
+/**
+ * Prefix root-absolute API calls (`/api/...`) with the mount path so the admin
+ * console's HTTP traffic resolves under `<mountPath>` — both the generated
+ * api-client (`basePath: ''`) and the hand-written `HttpClient` calls emit
+ * `/api/admin/...`; this rewrites them to `<mountPath>/api/admin/...`. No-op for
+ * the standalone (mount `''`).
+ *
+ * MUST run AFTER {@link authInterceptor}, whose auth-path check keys on the
+ * un-prefixed `/api/admin/auth/*` URL (see app.config `withInterceptors` order).
+ */
+export const mountPrefixInterceptor: HttpInterceptorFn = (req, next) => {
+  const prefix = resolveMountPrefix();
+  if (prefix && req.url.startsWith('/api/')) {
+    return next(req.clone({ url: prefix + req.url }));
+  }
+  return next(req);
+};

--- a/libs/nestjs/src/lib/admin/auth/auth.controller.spec.ts
+++ b/libs/nestjs/src/lib/admin/auth/auth.controller.spec.ts
@@ -1,0 +1,73 @@
+import type { Response } from 'express';
+
+import { AuthController } from './auth.controller';
+
+/**
+ * The refresh cookie's `path` must match the mount prefix under which the auth
+ * routes are served (`<mountPath>/api/admin/auth`), or the browser won't send the
+ * cookie back to the mounted `/refresh` endpoint. Standalone (no options) →
+ * `/api/admin/auth`; library `mountPath: '/storage'` → `/storage/api/admin/auth`.
+ */
+describe('AuthController — refresh cookie path is mount-aware', () => {
+  const tokens = {
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    refreshExpiresAt: new Date('2026-01-01T00:00:00Z'),
+    expiresIn: 900,
+  };
+
+  const makeAuth = () => ({
+    login: jest.fn().mockResolvedValue(tokens),
+    refresh: jest.fn().mockResolvedValue(tokens),
+    logout: jest.fn().mockResolvedValue(undefined),
+  });
+  const audit = { emit: jest.fn() };
+  const makeRes = () => ({ cookie: jest.fn(), clearCookie: jest.fn() }) as unknown as Response;
+  const req = { ip: '127.0.0.1', headers: { cookie: 'ob_refresh=tok' } };
+
+  it('scopes the cookie to /api/admin/auth for the standalone (no options)', async () => {
+    const auth = makeAuth();
+    const ctrl = new AuthController(auth as never, audit as never, undefined);
+    const res = makeRes();
+
+    await ctrl.login({ username: 'admin', password: 'pw' } as never, req as never, res);
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      'ob_refresh',
+      'refresh',
+      expect.objectContaining({ path: '/api/admin/auth', httpOnly: true, sameSite: 'strict' }),
+    );
+  });
+
+  it('scopes the cookie to <mountPath>/api/admin/auth under a mount', async () => {
+    const auth = makeAuth();
+    const ctrl = new AuthController(auth as never, audit as never, {
+      mountPath: '/storage',
+    } as never);
+    const res = makeRes();
+
+    await ctrl.login({ username: 'admin', password: 'pw' } as never, req as never, res);
+    expect(res.cookie).toHaveBeenCalledWith(
+      'ob_refresh',
+      'refresh',
+      expect.objectContaining({ path: '/storage/api/admin/auth' }),
+    );
+
+    // refresh rotates + re-sets the cookie at the same path.
+    await ctrl.refresh(req as never, res);
+    expect((res.cookie as jest.Mock).mock.calls.at(-1)?.[2]).toMatchObject({
+      path: '/storage/api/admin/auth',
+    });
+  });
+
+  it('clears the cookie at the mounted path on logout', async () => {
+    const auth = makeAuth();
+    const ctrl = new AuthController(auth as never, audit as never, {
+      mountPath: '/storage',
+    } as never);
+    const res = makeRes();
+
+    await ctrl.logout({ ...req, user: { username: 'admin' } } as never, res);
+    expect(res.clearCookie).toHaveBeenCalledWith('ob_refresh', { path: '/storage/api/admin/auth' });
+  });
+});

--- a/libs/nestjs/src/lib/admin/auth/auth.controller.ts
+++ b/libs/nestjs/src/lib/admin/auth/auth.controller.ts
@@ -3,6 +3,8 @@ import {
   Controller,
   Get,
   HttpCode,
+  Inject,
+  Optional,
   Post,
   Req,
   Res,
@@ -13,6 +15,7 @@ import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { ApiOkResponse } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 
+import { OPEN_BUCKET_OPTIONS, type ResolvedOpenBucketOptions } from '../../open-bucket-options';
 import { Public } from '../../common/auth/public.decorator';
 import { AuthService } from './auth.service';
 import { AuditService } from '../audit/audit.service';
@@ -34,10 +37,23 @@ const REFRESH_COOKIE = 'ob_refresh';
  */
 @Controller('api/admin/auth')
 export class AuthController {
+  /**
+   * Cookie `path` for the refresh token. The auth routes are mounted under
+   * `<mountPath>/api/admin/auth` (RouterModule prefixes the controller in library
+   * mode), so the cookie must be scoped to the SAME prefix or the browser won't
+   * send it to the mounted `/refresh` endpoint. `''` (standalone) → `/api/admin/auth`.
+   */
+  private readonly cookiePath: string;
+
   constructor(
     private readonly auth: AuthService,
     private readonly audit: AuditService,
-  ) {}
+    // Library mode supplies the resolved options (for `mountPath`); the standalone
+    // app does not (it mounts at the root, so `mountPath` is '').
+    @Optional() @Inject(OPEN_BUCKET_OPTIONS) options?: ResolvedOpenBucketOptions,
+  ) {
+    this.cookiePath = `${options?.mountPath ?? ''}/api/admin/auth`;
+  }
 
   @Public()
   @UseGuards(ThrottlerGuard)
@@ -85,7 +101,7 @@ export class AuthController {
   ): Promise<void> {
     const raw = readCookie(req, REFRESH_COOKIE);
     await this.auth.logout(raw);
-    res.clearCookie(REFRESH_COOKIE, { path: '/api/admin/auth' });
+    res.clearCookie(REFRESH_COOKIE, { path: this.cookiePath });
     const username = (req as Request & { user?: { username?: string } }).user?.username ?? 'unknown';
     this.audit.emit({ event: 'admin.logout', subject: username });
   }
@@ -114,7 +130,7 @@ export class AuthController {
       httpOnly: true,
       secure: true,
       sameSite: 'strict',
-      path: '/api/admin/auth',
+      path: this.cookiePath,
       expires: expiresAt,
     });
   }


### PR DESCRIPTION
## Problem

With `OpenBucketModule.forRoot({ mountPath: '/storage', admin: { serveUi: true } })`,
the admin console loads but is unusable:

```
POST http://localhost:3000/api/admin/auth/login    404 (Not Found)
POST http://localhost:3000/api/admin/auth/refresh  404 (Not Found)
```

The API is actually mounted at `/storage/api/admin/...` (verified:
`/storage/api/admin/auth/login` → 400, `/api/admin/auth/login` → 404), but the SPA
calls the un-prefixed path. Two independent mount-unaware assumptions:

### 1. Frontend built every URL root-absolute
Both the generated api-client (`basePath: ''`) and the hand-written `HttpClient`
calls emit `/api/admin/...`; the object share link emits `/<bucket>/<key>`. None
carry the mount.

**Fix:** `mountPrefixInterceptor` derives the mount from the SPA's `<base href>`
(the backend already rewrites it to `<mountPath>/admin/`) and prepends it to every
`/api/*` request — covering login/refresh/me, all CRUD, upload, download,
backup/restore. Registered **after** `authInterceptor` (whose auth-path check keys
on the un-prefixed URL). The copy-URL share link is prefixed directly. No-op for
the standalone (base `/admin/` → `''`).

### 2. Backend refresh cookie was scoped to the wrong path
`AuthController` set/cleared the `ob_refresh` cookie with a hardcoded
`path=/api/admin/auth`, so the browser would never send it to
`<mountPath>/api/admin/auth/refresh` — session refresh stays broken even after the
URL fix. Now scoped to `<mountPath>/api/admin/auth` (injected from the resolved
options; `''` for the standalone → unchanged).

## Tests

- **Backend** `auth.controller.spec.ts` (new): cookie path is `/api/admin/auth`
  standalone, `/storage/api/admin/auth` under a mount, and logout clears at the
  mounted path. Runs in the nestjs suite.
- **Frontend** `mount-prefix.spec.ts` (new): prefix derivation from `<base href>`
  and interceptor rewriting (mounted / standalone / non-`/api` untouched). Mirrors
  the existing parked frontend specs.

## Verification

- nestjs unit suite: **534 passed** / 3 skipped
- `nx build openbucket-frontend`, `nx build nestjs`, `nx lint` (both): clean, 0 errors
- Manually confirmed against the live consumer that the API is under `/storage` and
  the derivation matches the served `<base href="/storage/admin/">`.

Ships in the next pre-release for end-to-end validation in a mounted consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)