### PR TITLE
refactor(admin-ui): compact-header fix + shared components + PageLayout (Tier 0-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ versions may include breaking changes.
 
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+
+- **Admin console (default "compact" layout) showed no page title or primary
+  action button.** The compact shell rendered only the page *subtitle*, so page
+  titles (e.g. "Buckets") and the header's primary action (e.g. "Create bucket")
+  were invisible on the default layout. Compact now renders the full page header
+  like the inset/sticky variants. The `PageHeaderService` also resets on
+  navigation so header state never leaks between routes.
 
 ## [0.1.0-alpha.4] — 2026-07-02
 

--- a/apps/openbucket-frontend/src/app/backup-restore/backup-restore.component.ts
+++ b/apps/openbucket-frontend/src/app/backup-restore/backup-restore.component.ts
@@ -12,6 +12,7 @@ import { HlmButton } from '@openbucket/spartan-ui/button';
 import { BucketsAdminService } from '@openbucket/api-client';
 import { notify } from '../shared/ui/notify';
 import { ConfirmDialogComponent } from '../shared/ui/confirm-dialog.component';
+import { PageHeaderService } from '../layout/shell/services';
 
 /**
  * Admin Backup & Restore. Two scopes:
@@ -28,10 +29,7 @@ import { ConfirmDialogComponent } from '../shared/ui/confirm-dialog.component';
   providers: [provideIcons({ lucideDownload, lucideUpload, lucideDatabase, lucideServer })],
   template: `
     <div class="mx-auto max-w-3xl space-y-6 p-6">
-      <header class="space-y-1">
-        <h1 class="text-2xl font-semibold">{{ 'backupRestore.title' | translate }}</h1>
-        <p class="text-muted-foreground text-sm">{{ 'backupRestore.subtitle' | translate }}</p>
-      </header>
+      <!-- Title + subtitle render through the unified page header (PageHeaderService). -->
 
       <!-- Per-bucket -->
       <section hlmCard>
@@ -112,6 +110,7 @@ import { ConfirmDialogComponent } from '../shared/ui/confirm-dialog.component';
 export class BackupRestoreComponent {
   private readonly http = inject(HttpClient);
   private readonly bucketsApi = inject(BucketsAdminService);
+  private readonly pageHeader = inject(PageHeaderService);
   private readonly confirmDialog = viewChild.required(ConfirmDialogComponent);
 
   readonly buckets = signal<string[]>([]);
@@ -123,6 +122,7 @@ export class BackupRestoreComponent {
   readonly confirmPhrase = signal<string | null>(null);
 
   constructor() {
+    this.pageHeader.setPageHeader('backupRestore.title', 'backupRestore.subtitle');
     void this.loadBuckets();
   }
 

--- a/apps/openbucket-frontend/src/app/buckets/bucket-detail.component.ts
+++ b/apps/openbucket-frontend/src/app/buckets/bucket-detail.component.ts
@@ -2,7 +2,6 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
-  OnDestroy,
   OnInit,
   inject,
   signal,
@@ -14,7 +13,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucidePlus, lucideTrash2 } from '@ng-icons/lucide';
-import { HlmTabsImports } from '@openbucket/spartan-ui/tabs';
 import { HlmButton } from '@openbucket/spartan-ui/button';
 import { HlmSwitch } from '@openbucket/spartan-ui/switch';
 import { HlmBadge } from '@openbucket/spartan-ui/badge';
@@ -39,6 +37,7 @@ import { RelativeTimePipe } from '../shared/ui/relative-time.pipe';
 import { ByteSizePipe } from '../shared/ui/byte-size.pipe';
 import { notify } from '../shared/ui/notify';
 import { PageHeaderService } from '../layout/shell/services';
+import { PageLayoutComponent, type PageTab } from '../layout/components/page-layout/page-layout.component';
 
 /**
  * Bucket-detail tabbed page (STORY-0613): manages bucket-level S3 config over the
@@ -53,7 +52,7 @@ import { PageHeaderService } from '../layout/shell/services';
     FormsModule,
     TranslateModule,
     NgIcon,
-    HlmTabsImports,
+    PageLayoutComponent,
     HlmButton,
     HlmSwitch,
     HlmBadge,
@@ -71,30 +70,17 @@ import { PageHeaderService } from '../layout/shell/services';
   providers: [provideIcons({ lucidePlus, lucideTrash2 })],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="p-6">
-      <hlm-tabs
-        [tab]="activeTab()"
-        (tabActivated)="onTab($event)"
-      >
-        <hlm-tabs-list class="w-full justify-start overflow-x-auto">
-          <button hlmTabsTrigger="objects">{{ 'bucketDetail.tabs.objects' | translate }}</button>
-          <button hlmTabsTrigger="properties">{{ 'bucketDetail.tabs.properties' | translate }}</button>
-          <button hlmTabsTrigger="versioning">{{ 'bucketDetail.tabs.versioning' | translate }}</button>
-          <button hlmTabsTrigger="encryption">{{ 'bucketDetail.tabs.encryption' | translate }}</button>
-          <button hlmTabsTrigger="objectLock">{{ 'bucketDetail.tabs.objectLock' | translate }}</button>
-          <button hlmTabsTrigger="tags">{{ 'bucketDetail.tabs.tags' | translate }}</button>
-          <button hlmTabsTrigger="lifecycle">{{ 'bucketDetail.tabs.lifecycle' | translate }}</button>
-          <button hlmTabsTrigger="cors">{{ 'bucketDetail.tabs.cors' | translate }}</button>
-          <button hlmTabsTrigger="policy">{{ 'bucketDetail.tabs.policy' | translate }}</button>
-        </hlm-tabs-list>
+    <ob-page-layout
+      [tabs]="tabs"
+      [activeTab]="activeTab()"
+      (tabChange)="onTab($event)"
+    >
+      @switch (activeTab()) {
+        @case ('objects') {
+          <ob-object-browser [padded]="false" />
+        }
 
-        <div hlmTabsContent="objects" class="pt-4">
-          @if (activeTab() === 'objects') {
-            <ob-object-browser [padded]="false" />
-          }
-        </div>
-
-        <div hlmTabsContent="properties" class="pt-4">
+        @case ('properties') {
           @if (summary(); as s) {
             <div hlmCard class="max-w-lg">
               <div hlmCardContent class="space-y-2 pt-6 text-sm">
@@ -118,9 +104,9 @@ import { PageHeaderService } from '../layout/shell/services';
               </div>
             </div>
           }
-        </div>
+        }
 
-        <div hlmTabsContent="versioning" class="pt-4">
+        @case ('versioning') {
           <div hlmCard class="max-w-lg">
             <div hlmCardContent class="flex items-center justify-between gap-4 pt-6">
               <div>
@@ -134,9 +120,9 @@ import { PageHeaderService } from '../layout/shell/services';
               />
             </div>
           </div>
-        </div>
+        }
 
-        <div hlmTabsContent="encryption" class="pt-4">
+        @case ('encryption') {
           <div hlmCard class="max-w-lg">
             <div hlmCardContent class="flex items-center justify-between gap-4 pt-6">
               <div>
@@ -150,9 +136,9 @@ import { PageHeaderService } from '../layout/shell/services';
               />
             </div>
           </div>
-        </div>
+        }
 
-        <div hlmTabsContent="objectLock" class="pt-4">
+        @case ('objectLock') {
           <div hlmCard class="max-w-lg">
             <div hlmCardContent class="space-y-4 pt-6">
               <div class="flex items-center justify-between gap-4">
@@ -208,9 +194,9 @@ import { PageHeaderService } from '../layout/shell/services';
               </div>
             </div>
           </div>
-        </div>
+        }
 
-        <div hlmTabsContent="tags" class="pt-4">
+        @case ('tags') {
           <div hlmCard class="max-w-xl">
             <div hlmCardContent class="space-y-2 pt-6">
               @for (t of tagRows(); track $index) {
@@ -230,30 +216,30 @@ import { PageHeaderService } from '../layout/shell/services';
               </div>
             </div>
           </div>
-        </div>
+        }
 
-        <div hlmTabsContent="lifecycle" class="max-w-2xl pt-4">
-          @if (activeTab() === 'lifecycle') {
+        @case ('lifecycle') {
+          <div class="max-w-2xl">
             <ob-bucket-lifecycle-editor [bucket]="name()" />
-          }
-        </div>
+          </div>
+        }
 
-        <div hlmTabsContent="cors" class="max-w-2xl pt-4">
-          @if (activeTab() === 'cors') {
+        @case ('cors') {
+          <div class="max-w-2xl">
             <ob-bucket-cors-editor [bucket]="name()" />
-          }
-        </div>
+          </div>
+        }
 
-        <div hlmTabsContent="policy" class="max-w-2xl pt-4">
-          @if (activeTab() === 'policy') {
+        @case ('policy') {
+          <div class="max-w-2xl">
             <ob-bucket-policy-editor [bucket]="name()" />
-          }
-        </div>
-      </hlm-tabs>
-    </div>
+          </div>
+        }
+      }
+    </ob-page-layout>
   `,
 })
-export class BucketDetailComponent implements OnInit, OnDestroy {
+export class BucketDetailComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
@@ -262,6 +248,18 @@ export class BucketDetailComponent implements OnInit, OnDestroy {
 
   readonly name = signal('');
   readonly activeTab = signal('objects');
+
+  protected readonly tabs: PageTab[] = [
+    { id: 'objects', label: 'bucketDetail.tabs.objects' },
+    { id: 'properties', label: 'bucketDetail.tabs.properties' },
+    { id: 'versioning', label: 'bucketDetail.tabs.versioning' },
+    { id: 'encryption', label: 'bucketDetail.tabs.encryption' },
+    { id: 'objectLock', label: 'bucketDetail.tabs.objectLock' },
+    { id: 'tags', label: 'bucketDetail.tabs.tags' },
+    { id: 'lifecycle', label: 'bucketDetail.tabs.lifecycle' },
+    { id: 'cors', label: 'bucketDetail.tabs.cors' },
+    { id: 'policy', label: 'bucketDetail.tabs.policy' },
+  ];
   readonly summary = signal<BucketSummaryDto | null>(null);
   readonly encryptionEnabled = signal(false);
   readonly tagRows = signal<{ key: string; value: string }[]>([]);
@@ -285,7 +283,7 @@ export class BucketDetailComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.name.set(this.route.snapshot.paramMap.get('name') ?? '');
     this.pageHeader.setPageHeader(this.name());
-    this.pageHeader.setHasTabs(true);
+    // hasTabs is managed by <ob-page-layout>.
     void this.loadSummary();
     // Lazy-load each tab's config only when it becomes active, so unconfigured
     // features aren't all probed (and 404'd) on every page open.
@@ -294,10 +292,6 @@ export class BucketDetailComponent implements OnInit, OnDestroy {
       this.activeTab.set(tab);
       this.loadTab(tab);
     });
-  }
-
-  ngOnDestroy(): void {
-    this.pageHeader.setHasTabs(false);
   }
 
   private loadTab(tab: string): void {

--- a/apps/openbucket-frontend/src/app/buckets/bucket-list.component.ts
+++ b/apps/openbucket-frontend/src/app/buckets/bucket-list.component.ts
@@ -14,23 +14,25 @@ import { NgIcon, provideIcons } from '@ng-icons/core';
 import { lucideTrash2 } from '@ng-icons/lucide';
 import { HlmTableImports } from '@openbucket/spartan-ui/table';
 import { HlmBadge } from '@openbucket/spartan-ui/badge';
-import { HlmSkeleton } from '@openbucket/spartan-ui/skeleton';
-import { HlmEmptyImports } from '@openbucket/spartan-ui/empty';
 import { HlmButton } from '@openbucket/spartan-ui/button';
 
 import { ByteSizePipe } from '../shared/ui/byte-size.pipe';
 import { RelativeTimePipe } from '../shared/ui/relative-time.pipe';
 import { ConfirmDialogComponent } from '../shared/ui/confirm-dialog.component';
+import { ListStateComponent } from '../shared/ui/list-state.component';
+import { SortHeaderComponent, type SortDir } from '../shared/ui/sort-header.component';
 import { notify } from '../shared/ui/notify';
 import { PageHeaderService } from '../layout/shell/services';
 import { BucketsSignalStore } from './buckets.signal-store';
 import { BucketCreateDialogComponent } from './bucket-create-dialog.component';
 
+type BucketSortKey = 'name' | 'objects' | 'size' | 'created';
+
 /**
- * Bucket list (STORY-0603) on spartan-ng: HlmTable, status badges, skeleton /
- * empty states, a create dialog and a type-to-confirm delete, all wired to the
- * shared UX kit (notify / confirm-dialog). Title + Create action render through
- * the unified page header (PageHeaderService).
+ * Bucket list (STORY-0603) on spartan-ng: HlmTable, sortable headers, status
+ * badges, shared list-state (skeleton / error / empty), a create dialog and a
+ * type-to-confirm delete, all wired to the shared UX kit (notify /
+ * confirm-dialog). Title + Create action render through the unified page header.
  */
 @Component({
   standalone: true,
@@ -41,43 +43,32 @@ import { BucketCreateDialogComponent } from './bucket-create-dialog.component';
     NgIcon,
     HlmTableImports,
     HlmBadge,
-    HlmSkeleton,
-    HlmEmptyImports,
     HlmButton,
     ByteSizePipe,
     RelativeTimePipe,
     ConfirmDialogComponent,
+    ListStateComponent,
+    SortHeaderComponent,
     BucketCreateDialogComponent,
   ],
   providers: [provideIcons({ lucideTrash2 })],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="p-6">
-      @if (store.loading()) {
-        <div class="space-y-2">
-          @for (r of skeletonRows; track r) {
-            <div
-              hlmSkeleton
-              class="h-12 w-full rounded-md"
-            ></div>
-          }
-        </div>
-      } @else if (store.error()) {
-        <p class="text-sm font-medium text-destructive">{{ store.error() }}</p>
-      } @else if (store.count() === 0) {
-        <div hlm-empty>
-          <div hlm-empty-header>
-            <h3 hlmEmptyTitle>{{ 'buckets.empty' | translate }}</h3>
-            <p hlmEmptyDescription>{{ 'buckets.emptyHint' | translate }}</p>
-          </div>
-          <button
-            hlmBtn
-            (click)="createDialog().open()"
-          >
-            {{ 'buckets.create' | translate }}
-          </button>
-        </div>
-      } @else {
+      <ob-list-state
+        [loading]="store.loading()"
+        [error]="store.error()"
+        [empty]="store.count() === 0"
+        emptyTitle="buckets.empty"
+        emptyHint="buckets.emptyHint"
+      >
+        <button
+          listEmptyAction
+          hlmBtn
+          (click)="createDialog().open()"
+        >
+          {{ 'buckets.create' | translate }}
+        </button>
         <div hlmTableContainer>
           <table
             hlmTable
@@ -85,21 +76,45 @@ import { BucketCreateDialogComponent } from './bucket-create-dialog.component';
           >
             <thead hlmTHead>
               <tr hlmTr>
-                <th hlmTh>{{ 'buckets.name' | translate }}</th>
+                <th hlmTh>
+                  <ob-sort-header
+                    label="buckets.name"
+                    [active]="sortKey() === 'name'"
+                    [dir]="sortDir()"
+                    (sortToggle)="toggleSort('name')"
+                  />
+                </th>
                 <th hlmTh>{{ 'buckets.status' | translate }}</th>
                 <th
                   hlmTh
                   class="text-right"
                 >
-                  {{ 'buckets.objects' | translate }}
+                  <ob-sort-header
+                    label="buckets.objects"
+                    [active]="sortKey() === 'objects'"
+                    [dir]="sortDir()"
+                    (sortToggle)="toggleSort('objects')"
+                  />
                 </th>
                 <th
                   hlmTh
                   class="text-right"
                 >
-                  {{ 'buckets.size' | translate }}
+                  <ob-sort-header
+                    label="buckets.size"
+                    [active]="sortKey() === 'size'"
+                    [dir]="sortDir()"
+                    (sortToggle)="toggleSort('size')"
+                  />
                 </th>
-                <th hlmTh>{{ 'buckets.created' | translate }}</th>
+                <th hlmTh>
+                  <ob-sort-header
+                    label="buckets.created"
+                    [active]="sortKey() === 'created'"
+                    [dir]="sortDir()"
+                    (sortToggle)="toggleSort('created')"
+                  />
+                </th>
                 <th
                   hlmTh
                   class="w-12 text-right"
@@ -168,7 +183,7 @@ import { BucketCreateDialogComponent } from './bucket-create-dialog.component';
             </tbody>
           </table>
         </div>
-      }
+      </ob-list-state>
     </div>
 
     <ob-bucket-create-dialog />
@@ -188,12 +203,32 @@ export class BucketListComponent implements OnInit, OnDestroy {
   protected readonly createDialog = viewChild.required(BucketCreateDialogComponent);
   protected readonly confirmDialog = viewChild.required(ConfirmDialogComponent);
 
-  protected readonly skeletonRows = [0, 1, 2, 3, 4];
   protected readonly deleteName = signal<string | null>(null);
+  protected readonly sortKey = signal<BucketSortKey>('name');
+  protected readonly sortDir = signal<SortDir>('asc');
 
-  protected readonly sorted = computed(() =>
-    [...this.store.items()].sort((a, b) => a.name.localeCompare(b.name)),
-  );
+  protected readonly sorted = computed(() => {
+    const key = this.sortKey();
+    const factor = this.sortDir() === 'asc' ? 1 : -1;
+    return [...this.store.items()].sort((a, b) => {
+      let cmp = 0;
+      switch (key) {
+        case 'name':
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case 'objects':
+          cmp = (a.objectCount ?? 0) - (b.objectCount ?? 0);
+          break;
+        case 'size':
+          cmp = (a.sizeBytes ?? 0) - (b.sizeBytes ?? 0);
+          break;
+        case 'created':
+          cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+          break;
+      }
+      return cmp * factor;
+    });
+  });
   protected readonly deleteDescription = computed(
     () =>
       `This permanently deletes "${this.deleteName() ?? ''}" and cannot be undone. The bucket must be empty.`,
@@ -210,6 +245,15 @@ export class BucketListComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.pageHeader.hideActionButton();
+  }
+
+  protected toggleSort(key: BucketSortKey): void {
+    if (this.sortKey() === key) {
+      this.sortDir.update((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      this.sortKey.set(key);
+      this.sortDir.set('asc');
+    }
   }
 
   protected async onDelete(name: string): Promise<void> {

--- a/apps/openbucket-frontend/src/app/home/home.component.ts
+++ b/apps/openbucket-frontend/src/app/home/home.component.ts
@@ -22,6 +22,7 @@ import { HlmEmptyImports } from '@openbucket/spartan-ui/empty';
 
 import { ByteSizePipe } from '../shared/ui/byte-size.pipe';
 import { RelativeTimePipe } from '../shared/ui/relative-time.pipe';
+import { StatCardComponent } from '../shared/ui/stat-card.component';
 import { BucketsSignalStore } from '../buckets/buckets.signal-store';
 import { PageHeaderService } from '../layout/shell/services';
 
@@ -42,6 +43,7 @@ import { PageHeaderService } from '../layout/shell/services';
     HlmEmptyImports,
     ByteSizePipe,
     RelativeTimePipe,
+    StatCardComponent,
   ],
   providers: [
     provideIcons({ lucideDatabase, lucideFile, lucideHardDrive, lucideKey, lucidePlus }),
@@ -63,51 +65,24 @@ import { PageHeaderService } from '../layout/shell/services';
         </div>
       } @else {
         <div class="grid gap-4 sm:grid-cols-3">
-          <div hlmCard>
-            <div
-              hlmCardHeader
-              class="flex-row items-center justify-between gap-2 pb-2"
-            >
-              <span hlmCardDescription>{{ 'dashboard.totalBuckets' | translate }}</span>
-              <ng-icon
-                name="lucideDatabase"
-                class="text-muted-foreground text-base"
-              />
-            </div>
-            <div hlmCardContent>
-              <p class="text-2xl font-semibold tabular-nums">{{ store.count() }}</p>
-            </div>
-          </div>
-          <div hlmCard>
-            <div
-              hlmCardHeader
-              class="flex-row items-center justify-between gap-2 pb-2"
-            >
-              <span hlmCardDescription>{{ 'dashboard.totalObjects' | translate }}</span>
-              <ng-icon
-                name="lucideFile"
-                class="text-muted-foreground text-base"
-              />
-            </div>
-            <div hlmCardContent>
-              <p class="text-2xl font-semibold tabular-nums">{{ totalObjects() }}</p>
-            </div>
-          </div>
-          <div hlmCard>
-            <div
-              hlmCardHeader
-              class="flex-row items-center justify-between gap-2 pb-2"
-            >
-              <span hlmCardDescription>{{ 'dashboard.totalSize' | translate }}</span>
-              <ng-icon
-                name="lucideHardDrive"
-                class="text-muted-foreground text-base"
-              />
-            </div>
-            <div hlmCardContent>
-              <p class="text-2xl font-semibold tabular-nums">{{ totalSize() | byteSize }}</p>
-            </div>
-          </div>
+          <ob-stat-card
+            label="dashboard.totalBuckets"
+            [value]="store.count()"
+            icon="lucideDatabase"
+            [loading]="store.loading()"
+          />
+          <ob-stat-card
+            label="dashboard.totalObjects"
+            [value]="totalObjects()"
+            icon="lucideFile"
+            [loading]="store.loading()"
+          />
+          <ob-stat-card
+            label="dashboard.totalSize"
+            [value]="totalSize() | byteSize"
+            icon="lucideHardDrive"
+            [loading]="store.loading()"
+          />
         </div>
 
         <div class="grid gap-4 md:grid-cols-2">

--- a/apps/openbucket-frontend/src/app/keys/keys-list.component.ts
+++ b/apps/openbucket-frontend/src/app/keys/keys-list.component.ts
@@ -15,24 +15,26 @@ import { HlmTableImports } from '@openbucket/spartan-ui/table';
 import { HlmBadge } from '@openbucket/spartan-ui/badge';
 import { HlmButton } from '@openbucket/spartan-ui/button';
 import { HlmSwitch } from '@openbucket/spartan-ui/switch';
-import { HlmSkeleton } from '@openbucket/spartan-ui/skeleton';
-import { HlmEmptyImports } from '@openbucket/spartan-ui/empty';
 import { HlmDropdownMenuImports } from '@openbucket/spartan-ui/dropdown-menu';
 import { CreatedKeyDto, KeySummaryDto } from '@openbucket/api-client';
 
 import { RelativeTimePipe } from '../shared/ui/relative-time.pipe';
 import { CopyButtonComponent } from '../shared/ui/copy-button.component';
 import { ConfirmDialogComponent } from '../shared/ui/confirm-dialog.component';
+import { ListStateComponent } from '../shared/ui/list-state.component';
+import { SortHeaderComponent, type SortDir } from '../shared/ui/sort-header.component';
 import { notify } from '../shared/ui/notify';
 import { PageHeaderService } from '../layout/shell/services';
 import { KeysSignalStore } from './keys.signal-store';
 import { KeyCreateDialogComponent } from './key-create-dialog.component';
 import { KeySecretOnceDialogComponent } from './key-secret-once-dialog.component';
 
+type KeySortKey = 'label' | 'lastUsed';
+
 /**
  * Access-keys management (STORY-0611): list/create/enable-disable/delete on
- * spartan-ng, with a one-time secret reveal. Title + Create action via the
- * unified page header.
+ * spartan-ng, with sortable headers, shared list-state, and a one-time secret
+ * reveal. Title + Create action via the unified page header.
  */
 @Component({
   selector: 'ob-keys-list',
@@ -44,12 +46,12 @@ import { KeySecretOnceDialogComponent } from './key-secret-once-dialog.component
     HlmBadge,
     HlmButton,
     HlmSwitch,
-    HlmSkeleton,
-    HlmEmptyImports,
     HlmDropdownMenuImports,
     RelativeTimePipe,
     CopyButtonComponent,
     ConfirmDialogComponent,
+    ListStateComponent,
+    SortHeaderComponent,
     KeyCreateDialogComponent,
     KeySecretOnceDialogComponent,
   ],
@@ -57,31 +59,21 @@ import { KeySecretOnceDialogComponent } from './key-secret-once-dialog.component
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="p-6">
-      @if (store.loading()) {
-        <div class="space-y-2">
-          @for (r of skeletonRows; track r) {
-            <div
-              hlmSkeleton
-              class="h-12 w-full rounded-md"
-            ></div>
-          }
-        </div>
-      } @else if (store.error()) {
-        <p class="text-destructive text-sm font-medium">{{ store.error() }}</p>
-      } @else if (store.count() === 0) {
-        <div hlm-empty>
-          <div hlm-empty-header>
-            <h3 hlmEmptyTitle>{{ 'keys.empty' | translate }}</h3>
-            <p hlmEmptyDescription>{{ 'keys.emptyHint' | translate }}</p>
-          </div>
-          <button
-            hlmBtn
-            (click)="createDialog().open()"
-          >
-            {{ 'keys.create' | translate }}
-          </button>
-        </div>
-      } @else {
+      <ob-list-state
+        [loading]="store.loading()"
+        [error]="store.error()"
+        [empty]="store.count() === 0"
+        emptyTitle="keys.empty"
+        emptyHint="keys.emptyHint"
+        [skeletonCount]="3"
+      >
+        <button
+          listEmptyAction
+          hlmBtn
+          (click)="createDialog().open()"
+        >
+          {{ 'keys.create' | translate }}
+        </button>
         <div hlmTableContainer>
           <table
             hlmTable
@@ -89,10 +81,24 @@ import { KeySecretOnceDialogComponent } from './key-secret-once-dialog.component
           >
             <thead hlmTHead>
               <tr hlmTr>
-                <th hlmTh>{{ 'keys.label' | translate }}</th>
+                <th hlmTh>
+                  <ob-sort-header
+                    label="keys.label"
+                    [active]="sortKey() === 'label'"
+                    [dir]="sortDir()"
+                    (sortToggle)="toggleSort('label')"
+                  />
+                </th>
                 <th hlmTh>{{ 'keys.accessKeyId' | translate }}</th>
                 <th hlmTh>{{ 'keys.role' | translate }}</th>
-                <th hlmTh>{{ 'keys.lastUsed' | translate }}</th>
+                <th hlmTh>
+                  <ob-sort-header
+                    label="keys.lastUsed"
+                    [active]="sortKey() === 'lastUsed'"
+                    [dir]="sortDir()"
+                    (sortToggle)="toggleSort('lastUsed')"
+                  />
+                </th>
                 <th hlmTh>{{ 'keys.enabled' | translate }}</th>
                 <th
                   hlmTh
@@ -103,7 +109,7 @@ import { KeySecretOnceDialogComponent } from './key-secret-once-dialog.component
               </tr>
             </thead>
             <tbody hlmTBody>
-              @for (k of store.items(); track k.id) {
+              @for (k of sorted(); track k.id) {
                 <tr hlmTr>
                   <td
                     hlmTd
@@ -176,7 +182,7 @@ import { KeySecretOnceDialogComponent } from './key-secret-once-dialog.component
             </tbody>
           </table>
         </div>
-      }
+      </ob-list-state>
     </div>
 
     <ob-key-create-dialog (created)="onCreated($event)" />
@@ -197,8 +203,26 @@ export class KeysListComponent implements OnInit, OnDestroy {
   protected readonly secretDialog = viewChild.required(KeySecretOnceDialogComponent);
   protected readonly confirmDialog = viewChild.required(ConfirmDialogComponent);
 
-  protected readonly skeletonRows = [0, 1, 2];
   protected readonly deleteTarget = signal<KeySummaryDto | null>(null);
+  protected readonly sortKey = signal<KeySortKey>('label');
+  protected readonly sortDir = signal<SortDir>('asc');
+
+  protected readonly sorted = computed(() => {
+    const key = this.sortKey();
+    const factor = this.sortDir() === 'asc' ? 1 : -1;
+    return [...this.store.items()].sort((a, b) => {
+      let cmp = 0;
+      if (key === 'label') {
+        cmp = (a.label ?? '').localeCompare(b.label ?? '');
+      } else {
+        // lastUsed: nulls (never used) sort last in ascending order.
+        const at = a.lastUsedAt ? new Date(a.lastUsedAt).getTime() : -Infinity;
+        const bt = b.lastUsedAt ? new Date(b.lastUsedAt).getTime() : -Infinity;
+        cmp = at - bt;
+      }
+      return cmp * factor;
+    });
+  });
   protected readonly deleteDescription = computed(
     () =>
       `Permanently delete the key "${this.deleteTarget()?.label ?? ''}"? Applications using it will stop working.`,
@@ -215,6 +239,15 @@ export class KeysListComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.pageHeader.hideActionButton();
+  }
+
+  protected toggleSort(key: KeySortKey): void {
+    if (this.sortKey() === key) {
+      this.sortDir.update((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      this.sortKey.set(key);
+      this.sortDir.set('asc');
+    }
   }
 
   onCreated(key: CreatedKeyDto): void {

--- a/apps/openbucket-frontend/src/app/layout/components/page-layout/page-layout.component.ts
+++ b/apps/openbucket-frontend/src/app/layout/components/page-layout/page-layout.component.ts
@@ -1,0 +1,85 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  input,
+  OnDestroy,
+  output,
+  ViewEncapsulation,
+} from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { HlmTabsImports } from '@openbucket/spartan-ui/tabs';
+import { PageTabsVariantService } from './page-tabs-variant.service';
+import { PageHeaderService } from '../../shell/services';
+
+/** A single tab in {@link PageLayoutComponent}. `id` is the tab key (also the `?tab=` value). */
+export interface PageTab {
+  id: string;
+  /** i18n key for the tab label. */
+  label: string;
+}
+
+/**
+ * Reusable tabbed page scaffold: a tab bar (style driven by the user's
+ * `tabsVariant` preference) plus a padded content area. Tab BODIES are projected
+ * (`<ng-content>`), so the host keeps ownership of routing/`?tab=` sync and lazy
+ * content — this component only renders the bar and reports `hasTabs`.
+ *
+ * ```html
+ * <ob-page-layout [tabs]="tabs" [activeTab]="activeTab()" (tabChange)="onTab($event)">
+ *   @switch (activeTab()) { @case ('objects') { … } }
+ * </ob-page-layout>
+ * ```
+ */
+@Component({
+  selector: 'ob-page-layout',
+  standalone: true,
+  imports: [TranslateModule, ...HlmTabsImports],
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="flex h-full flex-col">
+      @if (tabs().length > 0) {
+        <div class="bg-background px-6" [class.border-b]="tabsVariant.variant() === 'line'">
+          <hlm-tabs [tab]="activeTab()" (tabActivated)="tabChange.emit($event)">
+            <hlm-tabs-list
+              [variant]="tabsVariant.variant()"
+              class="justify-start overflow-x-auto"
+              aria-label="Page navigation tabs"
+            >
+              @for (tab of tabs(); track tab.id) {
+                <button [hlmTabsTrigger]="tab.id">{{ tab.label | translate }}</button>
+              }
+            </hlm-tabs-list>
+          </hlm-tabs>
+        </div>
+      }
+
+      <div class="flex-1 overflow-auto">
+        <div class="p-6">
+          <ng-content />
+        </div>
+      </div>
+    </div>
+  `,
+})
+export class PageLayoutComponent implements OnDestroy {
+  protected readonly tabsVariant = inject(PageTabsVariantService);
+  private readonly pageHeader = inject(PageHeaderService);
+
+  readonly tabs = input<PageTab[]>([]);
+  /** The active tab id (owned by the host, typically synced to `?tab=`). */
+  readonly activeTab = input<string>('');
+  /** Emitted when a tab is clicked; the host updates its route/`?tab=`. */
+  readonly tabChange = output<string>();
+
+  constructor() {
+    // Toggle the page-header bottom border to butt up against the tab strip.
+    effect(() => this.pageHeader.setHasTabs(this.tabs().length > 0));
+  }
+
+  ngOnDestroy(): void {
+    this.pageHeader.setHasTabs(false);
+  }
+}

--- a/apps/openbucket-frontend/src/app/layout/components/page-layout/page-tabs-variant.service.ts
+++ b/apps/openbucket-frontend/src/app/layout/components/page-layout/page-tabs-variant.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, inject, computed } from '@angular/core';
+import { AppearanceStore, type TabsVariant } from '../../../core/platform/common/appearance';
+
+/**
+ * Derives the page tab style (`default` | `line`, matching Spartan's
+ * `hlm-tabs-list` variants) from the persisted {@link AppearanceStore}, so the
+ * user preference applies everywhere `PageLayoutComponent` renders tabs.
+ */
+@Injectable({ providedIn: 'root' })
+export class PageTabsVariantService {
+  private readonly appearance = inject(AppearanceStore);
+
+  readonly variant = computed(() => this.appearance.tabsVariant());
+
+  setVariant(variant: TabsVariant): void {
+    this.appearance.setTabsVariant(variant);
+  }
+
+  toggle(): void {
+    this.setVariant(this.variant() === 'default' ? 'line' : 'default');
+  }
+}

--- a/apps/openbucket-frontend/src/app/layout/shell/compact/compact-shell.component.ts
+++ b/apps/openbucket-frontend/src/app/layout/shell/compact/compact-shell.component.ts
@@ -7,7 +7,7 @@ import { RouterOutlet } from '@angular/router';
 import { HlmSidebarImports } from '@openbucket/spartan-ui/sidebar';
 import { CompactSidebar } from './components/compact-sidebar.component';
 import { CompactHeader } from './components/compact-header.component';
-import { PageSubheaderComponent } from '../components';
+import { PageHeaderComponent } from '../components';
 
 @Component({
   selector: 'ob-compact-shell',
@@ -16,7 +16,7 @@ import { PageSubheaderComponent } from '../components';
     HlmSidebarImports,
     CompactSidebar,
     CompactHeader,
-    PageSubheaderComponent,
+    PageHeaderComponent,
     RouterOutlet,
   ],
   encapsulation: ViewEncapsulation.None,
@@ -32,7 +32,10 @@ import { PageSubheaderComponent } from '../components';
       >
         <ob-compact-header class="sticky top-0 bg-background z-10" />
         <div class="flex-1 flex flex-col bg-muted/10 min-h-0">
-          <ob-page-subheader />
+          <!-- Full page header (title + subtitle + primary action). Previously
+               rendered <ob-page-subheader> (subtitle only), which dropped the page
+               title AND the primary action on the default (compact) variant. -->
+          <ob-page-header />
           <div class="flex-1 overflow-auto">
             <router-outlet />
           </div>

--- a/apps/openbucket-frontend/src/app/layout/shell/services/page-header.service.ts
+++ b/apps/openbucket-frontend/src/app/layout/shell/services/page-header.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, signal } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
+import { NavigationStart, Router } from '@angular/router';
 
 @Injectable({ providedIn: 'root' })
 export class PageHeaderService {
-  private readonly _pageTitle = signal<string>('Dashboard');
+  private readonly _pageTitle = signal<string>('');
   private readonly _pageSubtitle = signal<string>('');
   private readonly _showAction = signal<boolean>(false);
   private readonly _actionLabel = signal<string>('Quick Create');
@@ -14,6 +15,25 @@ export class PageHeaderService {
   readonly showAction = this._showAction.asReadonly();
   readonly actionLabel = this._actionLabel.asReadonly();
   readonly hasTabs = this._hasTabs.asReadonly();
+
+  constructor() {
+    // Clear header state on every navigation so a page that doesn't set (part of)
+    // the header never inherits the previous route's title / subtitle / action /
+    // tabs. Fires on NavigationStart, before the next route's component sets its
+    // own header, so pages no longer need manual ngOnDestroy cleanup.
+    inject(Router).events.subscribe((e) => {
+      if (e instanceof NavigationStart) this.reset();
+    });
+  }
+
+  /** Reset the header to empty (called automatically on navigation). */
+  reset(): void {
+    this._pageTitle.set('');
+    this._pageSubtitle.set('');
+    this._hasTabs.set(false);
+    this._showAction.set(false);
+    this._actionCallback = null;
+  }
 
   setTitle(title: string): void {
     this._pageTitle.set(title);

--- a/apps/openbucket-frontend/src/app/layout/sidebar/components/sidebar-renderer.component.ts
+++ b/apps/openbucket-frontend/src/app/layout/sidebar/components/sidebar-renderer.component.ts
@@ -46,7 +46,7 @@ import { SidebarConfig } from '../types';
     }),
   ],
   template: `
-    @for (group of config().groups; track group.id) {
+    @for (group of visibleGroups(); track group.id) {
       @if (group.collapsible) {
         <hlm-collapsible
           [expanded]="group.defaultOpen ?? false"
@@ -305,6 +305,14 @@ export class SidebarRendererComponent {
   private readonly _sidebarService = inject(HlmSidebarService);
 
   public readonly config = input.required<SidebarConfig>();
+
+  /**
+   * Drop groups that have no items so a conditionally-populated group never
+   * renders a bare section header/label. Static configs are unaffected.
+   */
+  protected readonly visibleGroups = computed(() =>
+    this.config().groups.filter((group) => group.items.length > 0),
+  );
 
   protected readonly Array = Array;
 

--- a/apps/openbucket-frontend/src/app/shared/ui/list-state.component.ts
+++ b/apps/openbucket-frontend/src/app/shared/ui/list-state.component.ts
@@ -1,0 +1,62 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { HlmSkeleton } from '@openbucket/spartan-ui/skeleton';
+import { HlmEmptyImports } from '@openbucket/spartan-ui/empty';
+
+/**
+ * Shared loading / error / empty scaffold for list pages, so each list stops
+ * re-implementing the same skeleton → error → empty → content ladder.
+ *
+ * Usage:
+ * ```html
+ * <ob-list-state [loading]="store.loading()" [error]="store.error()"
+ *                [empty]="store.count() === 0" emptyTitle="buckets.empty"
+ *                emptyHint="buckets.emptyHint">
+ *   <button listEmptyAction hlmBtn (click)="create()">Create</button>
+ *   <table hlmTable>…</table>   <!-- default slot: the loaded content -->
+ * </ob-list-state>
+ * ```
+ */
+@Component({
+  selector: 'ob-list-state',
+  standalone: true,
+  imports: [TranslateModule, HlmSkeleton, HlmEmptyImports],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (loading()) {
+      <div class="space-y-2">
+        @for (r of skeletonRows(); track r) {
+          <div hlmSkeleton class="h-12 w-full rounded-md"></div>
+        }
+      </div>
+    } @else if (error()) {
+      <p class="text-destructive text-sm font-medium">{{ error() }}</p>
+    } @else if (empty()) {
+      <div hlm-empty>
+        <div hlm-empty-header>
+          <h3 hlmEmptyTitle>{{ emptyTitle() | translate }}</h3>
+          @if (emptyHint()) {
+            <p hlmEmptyDescription>{{ emptyHint()! | translate }}</p>
+          }
+        </div>
+        <ng-content select="[listEmptyAction]" />
+      </div>
+    } @else {
+      <ng-content />
+    }
+  `,
+})
+export class ListStateComponent {
+  readonly loading = input(false);
+  readonly error = input<string | null>(null);
+  readonly empty = input(false);
+  /** i18n key for the empty-state title. */
+  readonly emptyTitle = input('');
+  /** i18n key for the empty-state hint (optional). */
+  readonly emptyHint = input<string | null>(null);
+  readonly skeletonCount = input(5);
+
+  protected readonly skeletonRows = computed(() =>
+    Array.from({ length: this.skeletonCount() }, (_, i) => i),
+  );
+}

--- a/apps/openbucket-frontend/src/app/shared/ui/sort-header.component.ts
+++ b/apps/openbucket-frontend/src/app/shared/ui/sort-header.component.ts
@@ -1,0 +1,52 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { lucideArrowDown, lucideArrowUp, lucideArrowUpDown } from '@ng-icons/lucide';
+import { HlmButton } from '@openbucket/spartan-ui/button';
+
+export type SortDir = 'asc' | 'desc';
+
+/**
+ * Clickable, sortable table-header label. Renders inside an `hlmTh`. Shows a
+ * neutral up/down glyph when inactive and a direction arrow when it's the active
+ * sort column; emits `toggle` on click. Sort state itself lives in the host
+ * component (a `sortKey`/`sortDir` signal pair).
+ *
+ * ```html
+ * <th hlmTh>
+ *   <ob-sort-header label="buckets.name" [active]="sortKey() === 'name'"
+ *                   [dir]="sortDir()" (toggle)="toggleSort('name')" />
+ * </th>
+ * ```
+ */
+@Component({
+  selector: 'ob-sort-header',
+  standalone: true,
+  imports: [TranslateModule, NgIcon, HlmButton],
+  providers: [provideIcons({ lucideArrowUp, lucideArrowDown, lucideArrowUpDown })],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <button
+      hlmBtn
+      variant="ghost"
+      size="sm"
+      class="-ml-2 h-8 gap-1.5 data-[active=true]:text-foreground"
+      [attr.data-active]="active()"
+      [attr.aria-label]="(label() | translate) + ': ' + (active() ? dir() : 'not sorted')"
+      (click)="sortToggle.emit()"
+    >
+      <span>{{ label() | translate }}</span>
+      <ng-icon [name]="glyph()" class="text-muted-foreground text-sm" />
+    </button>
+  `,
+})
+export class SortHeaderComponent {
+  readonly label = input.required<string>();
+  readonly active = input(false);
+  readonly dir = input<SortDir>('asc');
+  readonly sortToggle = output<void>();
+
+  protected readonly glyph = computed(() =>
+    !this.active() ? 'lucideArrowUpDown' : this.dir() === 'asc' ? 'lucideArrowUp' : 'lucideArrowDown',
+  );
+}

--- a/apps/openbucket-frontend/src/app/shared/ui/stat-card.component.ts
+++ b/apps/openbucket-frontend/src/app/shared/ui/stat-card.component.ts
@@ -1,0 +1,46 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { NgIcon } from '@ng-icons/core';
+import { HlmCardImports } from '@openbucket/spartan-ui/card';
+import { HlmSkeleton } from '@openbucket/spartan-ui/skeleton';
+
+/**
+ * Compact KPI / stat tile — a label, a large value, and a trailing icon, with a
+ * loading skeleton. Replaces the repeated inline `hlmCard` KPI blocks.
+ *
+ * The icon is resolved from the HOST component's `provideIcons(...)` registry
+ * (pass the lucide icon name), so this component stays icon-agnostic.
+ */
+@Component({
+  selector: 'ob-stat-card',
+  standalone: true,
+  imports: [TranslateModule, NgIcon, HlmCardImports, HlmSkeleton],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div hlmCard>
+      <div hlmCardHeader class="flex-row items-center justify-between gap-2 pb-2">
+        <span hlmCardDescription>{{ label() | translate }}</span>
+        @if (icon()) {
+          <ng-icon [name]="icon()!" class="text-muted-foreground text-base" />
+        }
+      </div>
+      <div hlmCardContent>
+        @if (loading()) {
+          <div hlmSkeleton class="h-8 w-24"></div>
+        } @else {
+          <p class="text-2xl font-semibold tabular-nums">{{ value() }}</p>
+        }
+      </div>
+    </div>
+  `,
+})
+export class StatCardComponent {
+  /** i18n key for the metric label. */
+  readonly label = input.required<string>();
+  /** The metric value (pre-formatted; e.g. a count or a byte-size string). */
+  readonly value = input.required<string | number>();
+  /** Lucide icon name (must be registered by the host via `provideIcons`). */
+  readonly icon = input<string | null>(null);
+  /** Show a skeleton instead of the value while data loads. */
+  readonly loading = input<boolean>(false);
+}


### PR DESCRIPTION
Admin-UI refactor from the audrey (frontendbay) comparison. **Correctness/component work — please QA visually before merging** (the SPA can't be driven headlessly here; the frontend unit harness is parked). Everything below is `nx build` + `nx lint` clean.

## 🐞 Bug fixed
Default `compact` shell rendered only the subtitle → **page titles + primary action button were invisible** on the default layout. Compact now renders the full `<ob-page-header>`.

## Tier 0
- `PageHeaderService` resets on `NavigationStart` (no stale headers; empty default title).
- Sidebar drops empty groups (future-proofing).

## Shared components (new)
- **`ob-stat-card`** — KPI tile w/ loading skeleton → home KPIs.
- **`ob-list-state`** — DRY skeleton/error/empty ladder → buckets + keys.
- **`ob-sort-header`** — sortable columns → buckets (name/objects/size/created), keys (label/lastUsed).
- **`ob-page-layout`** — reusable tabbed page scaffold (tab bar w/ `tabsVariant` preference, projected content, centralized `hasTabs`). **bucket-detail** migrated: 9 hand-rolled `hlm-tabs` panels → data-driven `tabs[]` + `@switch`, preserving `?tab=` deep-linking + lazy loading.
- **backup-restore** title routed through the unified page header.

## Deliberately deferred (with rationale)
- **Numbered pagination** on buckets/keys — short lists; low value, adds noise.
- **object-browser column sort** — it's server-marker-paged (sorting a page is misleading).
- **content-max-width revival** — needs a Settings UI + per-page width policy (data-table tabs want full width); would otherwise narrow the object browser.
- **Formly form migration (#10)** — see PR discussion. Migrating the validation-critical create dialogs + the policy/lifecycle/CORS editors blind is a functional-regression risk; recommended as a QA-in-the-loop follow-up.

## QA checklist
- [ ] Compact (default) layout shows page titles + "Create bucket" action
- [ ] Home KPI cards render (+ skeletons on load)
- [ ] Buckets/keys sort on header click; empty/error/skeleton states OK
- [ ] bucket-detail: all 9 tabs switch, deep-link via `?tab=`, editors load
- [ ] backup-restore title shows in the shell header

🤖 Generated with [Claude Code](https://claude.com/claude-code)