### PR TITLE
feat(admin-ui): consolidate 5 sidebar items + Appearance into Settings tabs

### DIFF
--- a/apps/openbucket-frontend/src/app/app.routes.ts
+++ b/apps/openbucket-frontend/src/app/app.routes.ts
@@ -1,6 +1,6 @@
 import { Routes } from '@angular/router';
 
-import { authGuard, fullAdminGuard, mustNotRotateGuard, unauthGuard } from './auth/auth.guard';
+import { authGuard, mustNotRotateGuard, unauthGuard } from './auth/auth.guard';
 
 /**
  * SPA routes (§5.11). `/login` and `/force-rotate` sit outside the shell;
@@ -72,40 +72,11 @@ export const appRoutes: Routes = [
           import('./objects/object-search.component').then((m) => m.ObjectSearchComponent),
       },
       {
-        path: 'keys',
-        loadComponent: () => import('./keys/keys-list.component').then((m) => m.KeysListComponent),
-      },
-      {
-        path: 'users',
-        // Full-admin only (EPIC-11): the fullAdminGuard redirects a read-only
-        // admin to `/`. The server-side RolesGuard remains authoritative.
-        canActivate: [fullAdminGuard],
-        data: { breadcrumb: 'sidebar.admin.users' },
-        loadComponent: () =>
-          import('./users/admin-users-list.component').then((m) => m.AdminUsersListComponent),
-      },
-      {
+        // Access Keys, Admin Users, Backup & Restore, Replication and Audit Log
+        // are now tabs inside Settings (selected via the `?tab=` query param).
         path: 'settings',
         loadComponent: () =>
           import('./settings/settings.component').then((m) => m.SettingsComponent),
-      },
-      {
-        path: 'backup-restore',
-        data: { breadcrumb: 'sidebar.admin.backupRestore' },
-        loadComponent: () =>
-          import('./backup-restore/backup-restore.component').then((m) => m.BackupRestoreComponent),
-      },
-      {
-        path: 'replication',
-        data: { breadcrumb: 'sidebar.admin.replication' },
-        loadComponent: () =>
-          import('./replication/replication.component').then((m) => m.ReplicationComponent),
-      },
-      {
-        path: 'audit',
-        data: { breadcrumb: 'sidebar.admin.audit' },
-        loadComponent: () =>
-          import('./audit/audit-log.component').then((m) => m.AuditLogComponent),
       },
       {
         path: 'about',

--- a/apps/openbucket-frontend/src/app/audit/audit-log.component.ts
+++ b/apps/openbucket-frontend/src/app/audit/audit-log.component.ts
@@ -17,7 +17,6 @@ import { BrnSelectImports } from '@spartan-ng/brain/select';
 import { RelativeTimePipe } from '../shared/ui/relative-time.pipe';
 import { CopyButtonComponent } from '../shared/ui/copy-button.component';
 import { ListStateComponent } from '../shared/ui/list-state.component';
-import { PageHeaderService } from '../layout/shell/services';
 import { AuditSignalStore } from './audit.signal-store';
 
 /** ISO 8601 → the value a `datetime-local` input expects (`YYYY-MM-DDTHH:mm`,
@@ -224,7 +223,6 @@ function localInputToIso(local: string): string | undefined {
 })
 export class AuditLogComponent implements OnInit {
   protected readonly store = inject(AuditSignalStore);
-  private readonly pageHeader = inject(PageHeaderService);
 
   protected readonly event = signal('');
   protected readonly subject = signal('');
@@ -233,7 +231,6 @@ export class AuditLogComponent implements OnInit {
   protected readonly to = signal('');
 
   constructor() {
-    this.pageHeader.setPageHeader('audit.title', 'audit.subtitle');
     // Hydrate the local controls from any preserved store filters (route re-entry).
     const f = this.store.filters();
     this.event.set(f.event ?? '');

--- a/apps/openbucket-frontend/src/app/backup-restore/backup-restore.component.ts
+++ b/apps/openbucket-frontend/src/app/backup-restore/backup-restore.component.ts
@@ -12,7 +12,6 @@ import { HlmButton } from '@openbucket/spartan-ui/button';
 import { BucketsAdminService } from '@openbucket/api-client';
 import { notify } from '../shared/ui/notify';
 import { ConfirmDialogComponent } from '../shared/ui/confirm-dialog.component';
-import { PageHeaderService } from '../layout/shell/services';
 
 /**
  * Admin Backup & Restore. Two scopes:
@@ -29,8 +28,6 @@ import { PageHeaderService } from '../layout/shell/services';
   providers: [provideIcons({ lucideDownload, lucideUpload, lucideDatabase, lucideServer })],
   template: `
     <div class="space-y-6 p-6">
-      <!-- Title + subtitle render through the unified page header (PageHeaderService). -->
-
       <!-- Per-bucket -->
       <section hlmCard>
         <div hlmCardHeader>
@@ -110,7 +107,6 @@ import { PageHeaderService } from '../layout/shell/services';
 export class BackupRestoreComponent {
   private readonly http = inject(HttpClient);
   private readonly bucketsApi = inject(BucketsAdminService);
-  private readonly pageHeader = inject(PageHeaderService);
   private readonly confirmDialog = viewChild.required(ConfirmDialogComponent);
 
   readonly buckets = signal<string[]>([]);
@@ -122,7 +118,6 @@ export class BackupRestoreComponent {
   readonly confirmPhrase = signal<string | null>(null);
 
   constructor() {
-    this.pageHeader.setPageHeader('backupRestore.title', 'backupRestore.subtitle');
     void this.loadBuckets();
   }
 

--- a/apps/openbucket-frontend/src/app/home/home.component.ts
+++ b/apps/openbucket-frontend/src/app/home/home.component.ts
@@ -150,7 +150,8 @@ const POLL_MS = 30_000;
               <a
                 hlmBtn
                 variant="outline"
-                routerLink="/keys"
+                routerLink="/settings"
+                [queryParams]="{ tab: 'keys' }"
               >
                 <ng-icon
                   name="lucideKey"

--- a/apps/openbucket-frontend/src/app/keys/keys-list.component.ts
+++ b/apps/openbucket-frontend/src/app/keys/keys-list.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  OnDestroy,
   OnInit,
   computed,
   inject,
@@ -30,7 +29,6 @@ import { ConfirmDialogComponent } from '../shared/ui/confirm-dialog.component';
 import { ListStateComponent } from '../shared/ui/list-state.component';
 import { SortHeaderComponent, type SortDir } from '../shared/ui/sort-header.component';
 import { notify } from '../shared/ui/notify';
-import { PageHeaderService } from '../layout/shell/services';
 import { AuthService } from '../auth/auth.service';
 import { KeysSignalStore } from './keys.signal-store';
 import { KeyCreateDialogComponent } from './key-create-dialog.component';
@@ -85,6 +83,17 @@ interface ConfirmConfig {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="p-6">
+      <!-- EPIC-11: no create action for read-only admins (UX; server is authoritative). -->
+      @if (!auth.isReadOnly()) {
+        <div class="mb-4 flex justify-end">
+          <button
+            hlmBtn
+            (click)="createDialog().open()"
+          >
+            {{ 'keys.create' | translate }}
+          </button>
+        </div>
+      }
       <ob-list-state
         [loading]="store.loading()"
         [error]="store.error()"
@@ -268,9 +277,8 @@ interface ConfirmConfig {
     />
   `,
 })
-export class KeysListComponent implements OnInit, OnDestroy {
+export class KeysListComponent implements OnInit {
   protected readonly store = inject(KeysSignalStore);
-  private readonly pageHeader = inject(PageHeaderService);
   protected readonly auth = inject(AuthService);
   private readonly i18n = inject(TranslateService);
 
@@ -305,20 +313,8 @@ export class KeysListComponent implements OnInit, OnDestroy {
     });
   });
 
-  constructor() {
-    this.pageHeader.setPageHeader('keys.title', 'keys.subtitle');
-    // EPIC-11: no create action for read-only admins (UX; server is authoritative).
-    if (!this.auth.isReadOnly()) {
-      this.pageHeader.setActionButton('keys.create', () => this.createDialog().open());
-    }
-  }
-
   ngOnInit(): void {
     void this.store.refresh();
-  }
-
-  ngOnDestroy(): void {
-    this.pageHeader.hideActionButton();
   }
 
   protected toggleSort(key: KeySortKey): void {

--- a/apps/openbucket-frontend/src/app/layout/shell/command-palette.component.ts
+++ b/apps/openbucket-frontend/src/app/layout/shell/command-palette.component.ts
@@ -67,11 +67,11 @@ import { CommandPaletteService } from './command-palette.service';
 
             <hlm-command-group>
               <span hlmCommandGroupLabel>{{ 'command.goTo' | translate }}</span>
-              @for (n of nav; track n.url) {
+              @for (n of nav; track n.label) {
                 <button
                   hlmCommandItem
                   [value]="n.label | translate"
-                  (selected)="go(n.url)"
+                  (selected)="go(n.url, n.queryParams)"
                 >
                   <ng-icon [name]="n.icon" />
                   {{ n.label | translate }}
@@ -108,7 +108,7 @@ import { CommandPaletteService } from './command-palette.service';
               <button
                 hlmCommandItem
                 [value]="'dashboard.createKey' | translate"
-                (selected)="go('/keys')"
+                (selected)="go('/settings', { tab: 'keys' })"
               >
                 <ng-icon name="lucideKey" />
                 {{ 'dashboard.createKey' | translate }}
@@ -154,12 +154,22 @@ export class CommandPaletteComponent {
   private gTimer: ReturnType<typeof setTimeout> | undefined;
 
   protected readonly buckets = computed(() => this.store.items());
-  protected readonly nav = [
+  protected readonly nav: {
+    label: string;
+    icon: string;
+    url: string;
+    queryParams?: Record<string, string>;
+  }[] = [
     { label: 'sidebar.storage.dashboard', icon: 'lucideLayoutDashboard', url: '/' },
     { label: 'sidebar.storage.buckets', icon: 'lucideDatabase', url: '/buckets' },
-    { label: 'sidebar.storage.keys', icon: 'lucideKey', url: '/keys' },
+    { label: 'sidebar.storage.keys', icon: 'lucideKey', url: '/settings', queryParams: { tab: 'keys' } },
     { label: 'sidebar.storage.settings', icon: 'lucideSettings', url: '/settings' },
-    { label: 'sidebar.admin.backupRestore', icon: 'lucideArchive', url: '/backup-restore' },
+    {
+      label: 'sidebar.admin.backupRestore',
+      icon: 'lucideArchive',
+      url: '/settings',
+      queryParams: { tab: 'backup-restore' },
+    },
   ];
 
   constructor() {
@@ -198,7 +208,7 @@ export class CommandPaletteComponent {
         void this.router.navigate(['/buckets']);
       } else if (e.key === 'k') {
         e.preventDefault();
-        void this.router.navigate(['/keys']);
+        void this.router.navigate(['/settings'], { queryParams: { tab: 'keys' } });
       }
     }
   }
@@ -208,9 +218,9 @@ export class CommandPaletteComponent {
     this.dialog().open();
   }
 
-  protected go(url: string): void {
+  protected go(url: string, queryParams?: Record<string, string>): void {
     this.dialog().close();
-    void this.router.navigate([url]);
+    void this.router.navigate([url], queryParams ? { queryParams } : undefined);
   }
 
   protected toggleTheme(): void {

--- a/apps/openbucket-frontend/src/app/layout/sidebar/data/sidebar.data.ts
+++ b/apps/openbucket-frontend/src/app/layout/sidebar/data/sidebar.data.ts
@@ -25,44 +25,13 @@ export const sidebarConfig: SidebarConfig = {
           icon: 'lucideSearch',
           url: '/search',
         }),
-        createSidebarConfig.item({
-          id: 'keys',
-          title: 'sidebar.storage.keys',
-          icon: 'lucideKey',
-          url: '/keys',
-        }),
-        createSidebarConfig.item({
-          id: 'users',
-          title: 'sidebar.admin.users',
-          icon: 'lucideUsers',
-          url: '/users',
-          // EPIC-11: full-admin only. Hidden from read-only admins (fullAdminGuard
-          // also redirects a deep-link); the server RolesGuard is authoritative.
-          requiresFullAdmin: true,
-        }),
+        // Access Keys, Admin Users, Backup & Restore, Replication and Audit Log
+        // now live as tabs inside /settings.
         createSidebarConfig.item({
           id: 'settings',
           title: 'sidebar.storage.settings',
           icon: 'lucideSettings',
           url: '/settings',
-        }),
-        createSidebarConfig.item({
-          id: 'backup-restore',
-          title: 'sidebar.admin.backupRestore',
-          icon: 'lucideArchive',
-          url: '/backup-restore',
-        }),
-        createSidebarConfig.item({
-          id: 'replication',
-          title: 'sidebar.admin.replication',
-          icon: 'lucideRefreshCw',
-          url: '/replication',
-        }),
-        createSidebarConfig.item({
-          id: 'audit',
-          title: 'sidebar.admin.audit',
-          icon: 'lucideScrollText',
-          url: '/audit',
         }),
       ],
     }),

--- a/apps/openbucket-frontend/src/app/replication/replication.component.ts
+++ b/apps/openbucket-frontend/src/app/replication/replication.component.ts
@@ -19,7 +19,6 @@ import { HlmBadge } from '@openbucket/spartan-ui/badge';
 import { StatCardComponent } from '../shared/ui/stat-card.component';
 import { ListStateComponent } from '../shared/ui/list-state.component';
 import { ConfirmDialogComponent } from '../shared/ui/confirm-dialog.component';
-import { PageHeaderService } from '../layout/shell/services';
 import { ReplicationSignalStore } from './replication.signal-store';
 
 /**
@@ -177,7 +176,6 @@ import { ReplicationSignalStore } from './replication.signal-store';
 })
 export class ReplicationComponent implements OnInit, OnDestroy {
   protected readonly store = inject(ReplicationSignalStore);
-  private readonly pageHeader = inject(PageHeaderService);
   private readonly confirmDialog = viewChild.required(ConfirmDialogComponent);
 
   protected readonly confirmTitle = signal('');
@@ -185,10 +183,6 @@ export class ReplicationComponent implements OnInit, OnDestroy {
 
   /** Human-readable instance-wide replication lag for the stat card. */
   protected readonly lagLabel = computed(() => this.formatLag(this.store.status()?.oldestPendingAgeMs ?? null));
-
-  constructor() {
-    this.pageHeader.setPageHeader('replication.title', 'replication.subtitle');
-  }
 
   ngOnInit(): void {
     void this.store.refresh();

--- a/apps/openbucket-frontend/src/app/settings/settings.component.ts
+++ b/apps/openbucket-frontend/src/app/settings/settings.component.ts
@@ -1,6 +1,16 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
 import { BrnSelectImports } from '@spartan-ng/brain/select';
 import { HlmSelectImports } from '@openbucket/spartan-ui/select';
 import { HlmCardImports } from '@openbucket/spartan-ui/card';
@@ -15,12 +25,25 @@ import {
 } from '../core/platform/common/appearance/store/appearance.store';
 import { type LocaleCode } from '../core/platform/common/locale/store/locale.store';
 import { PageHeaderService } from '../layout/shell/services';
+import {
+  PageLayoutComponent,
+  type PageTab,
+} from '../layout/components/page-layout/page-layout.component';
+import { AuthService } from '../auth/auth.service';
 import { ChangePasswordComponent } from './change-password.component';
+import { KeysListComponent } from '../keys/keys-list.component';
+import { AdminUsersListComponent } from '../users/admin-users-list.component';
+import { BackupRestoreComponent } from '../backup-restore/backup-restore.component';
+import { ReplicationComponent } from '../replication/replication.component';
+import { AuditLogComponent } from '../audit/audit-log.component';
 
 /**
- * Settings screen (STORY-0607): exposes the appearance engine — 12 color schemes,
- * light/dark/system, shell layout, language, reduced motion — plus change-password.
- * Everything is wired to the AppearanceStore (persisted to this browser).
+ * Settings screen (STORY-0607): a single tabbed page (mirrors the bucket-detail
+ * tab pattern) that consolidates every instance-level admin area. Tabs, in order:
+ * Appearance (the appearance engine + change-password), Access Keys, Admin Users
+ * (full-admin only, EPIC-11), Backup & Restore, Replication, Audit Log. The page
+ * header is set once here; the embedded feature components no longer own it. The
+ * active tab is driven by the `?tab=` query param (defaulting to `appearance`).
  */
 @Component({
   selector: 'ob-settings',
@@ -28,128 +51,183 @@ import { ChangePasswordComponent } from './change-password.component';
   imports: [
     FormsModule,
     TranslateModule,
+    PageLayoutComponent,
     HlmCardImports,
     HlmButton,
     HlmSwitch,
     HlmSelectImports,
     BrnSelectImports,
     ChangePasswordComponent,
+    KeysListComponent,
+    AdminUsersListComponent,
+    BackupRestoreComponent,
+    ReplicationComponent,
+    AuditLogComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="space-y-6 p-6">
-      <div hlmCard>
-        <div hlmCardHeader>
-          <h3 hlmCardTitle>{{ 'settings.appearance' | translate }}</h3>
-          <p hlmCardDescription>{{ 'settings.appearanceHint' | translate }}</p>
-        </div>
-        <div
-          hlmCardContent
-          class="space-y-6"
-        >
-          <div class="space-y-2">
-            <span class="text-sm font-medium">{{ 'settings.colorScheme' | translate }}</span>
-            <div class="flex flex-wrap gap-2">
-              @for (s of schemes; track s.value) {
-                <button
-                  type="button"
-                  class="ring-offset-background size-8 rounded-full border transition-transform hover:scale-110"
-                  [style.background-color]="s.color"
-                  [class.ring-2]="store.colorScheme() === s.value"
-                  [class.ring-ring]="store.colorScheme() === s.value"
-                  [class.ring-offset-2]="store.colorScheme() === s.value"
-                  [attr.aria-label]="s.label"
-                  [attr.aria-pressed]="store.colorScheme() === s.value"
-                  (click)="store.setColorScheme(s.value)"
-                ></button>
-              }
+    <ob-page-layout
+      [tabs]="tabs()"
+      [activeTab]="activeTab()"
+      (tabChange)="onTab($event)"
+    >
+      @switch (activeTab()) {
+        @case ('appearance') {
+          <div class="space-y-6">
+            <div hlmCard>
+              <div hlmCardHeader>
+                <h3 hlmCardTitle>{{ 'settings.appearance' | translate }}</h3>
+                <p hlmCardDescription>{{ 'settings.appearanceHint' | translate }}</p>
+              </div>
+              <div
+                hlmCardContent
+                class="space-y-6"
+              >
+                <div class="space-y-2">
+                  <span class="text-sm font-medium">{{ 'settings.colorScheme' | translate }}</span>
+                  <div class="flex flex-wrap gap-2">
+                    @for (s of schemes; track s.value) {
+                      <button
+                        type="button"
+                        class="ring-offset-background size-8 rounded-full border transition-transform hover:scale-110"
+                        [style.background-color]="s.color"
+                        [class.ring-2]="store.colorScheme() === s.value"
+                        [class.ring-ring]="store.colorScheme() === s.value"
+                        [class.ring-offset-2]="store.colorScheme() === s.value"
+                        [attr.aria-label]="s.label"
+                        [attr.aria-pressed]="store.colorScheme() === s.value"
+                        (click)="store.setColorScheme(s.value)"
+                      ></button>
+                    }
+                  </div>
+                </div>
+
+                <div class="space-y-2">
+                  <span class="text-sm font-medium">{{ 'settings.mode' | translate }}</span>
+                  <div class="flex gap-2">
+                    @for (t of themes; track t.value) {
+                      <button
+                        hlmBtn
+                        size="sm"
+                        [variant]="store.theme() === t.value ? 'default' : 'outline'"
+                        (click)="store.setTheme(t.value)"
+                      >
+                        {{ t.label | translate }}
+                      </button>
+                    }
+                  </div>
+                </div>
+
+                <div class="space-y-2">
+                  <span class="text-sm font-medium">{{ 'settings.contentWidth' | translate }}</span>
+                  <div class="flex flex-wrap gap-2">
+                    @for (cw of contentWidths; track cw.value) {
+                      <button
+                        hlmBtn
+                        size="sm"
+                        [variant]="store.contentMaxWidth() === cw.value ? 'default' : 'outline'"
+                        (click)="store.setContentMaxWidth(cw.value)"
+                      >
+                        {{ cw.label | translate }}
+                      </button>
+                    }
+                  </div>
+                </div>
+
+                <div class="space-y-2">
+                  <span class="text-sm font-medium">{{ 'settings.language' | translate }}</span>
+                  <brn-select
+                    hlm
+                    [ngModel]="store.locale()"
+                    (ngModelChange)="store.setLocale($event)"
+                  >
+                    <hlm-select-trigger class="w-48">
+                      <hlm-select-value />
+                    </hlm-select-trigger>
+                    <hlm-select-content>
+                      @for (l of locales; track l.value) {
+                        <hlm-option [value]="l.value">{{ l.label }}</hlm-option>
+                      }
+                    </hlm-select-content>
+                  </brn-select>
+                </div>
+
+                <div class="flex items-center justify-between gap-2">
+                  <div>
+                    <span class="text-sm font-medium">{{ 'settings.reducedMotion' | translate }}</span>
+                    <p class="text-muted-foreground text-xs">
+                      {{ 'settings.reducedMotionHint' | translate }}
+                    </p>
+                  </div>
+                  <hlm-switch
+                    [attr.aria-label]="'settings.reducedMotion' | translate"
+                    [checked]="store.reducedMotion()"
+                    (checkedChange)="store.setReducedMotion($event)"
+                  />
+                </div>
+
+                <div>
+                  <button
+                    hlmBtn
+                    variant="outline"
+                    size="sm"
+                    (click)="store.reset()"
+                  >
+                    {{ 'settings.reset' | translate }}
+                  </button>
+                </div>
+              </div>
             </div>
-          </div>
 
-          <div class="space-y-2">
-            <span class="text-sm font-medium">{{ 'settings.mode' | translate }}</span>
-            <div class="flex gap-2">
-              @for (t of themes; track t.value) {
-                <button
-                  hlmBtn
-                  size="sm"
-                  [variant]="store.theme() === t.value ? 'default' : 'outline'"
-                  (click)="store.setTheme(t.value)"
-                >
-                  {{ t.label | translate }}
-                </button>
-              }
-            </div>
+            <ob-change-password />
           </div>
+        }
 
-          <div class="space-y-2">
-            <span class="text-sm font-medium">{{ 'settings.contentWidth' | translate }}</span>
-            <div class="flex flex-wrap gap-2">
-              @for (cw of contentWidths; track cw.value) {
-                <button
-                  hlmBtn
-                  size="sm"
-                  [variant]="store.contentMaxWidth() === cw.value ? 'default' : 'outline'"
-                  (click)="store.setContentMaxWidth(cw.value)"
-                >
-                  {{ cw.label | translate }}
-                </button>
-              }
-            </div>
-          </div>
+        @case ('keys') {
+          <ob-keys-list />
+        }
 
-          <div class="space-y-2">
-            <span class="text-sm font-medium">{{ 'settings.language' | translate }}</span>
-            <brn-select
-              hlm
-              [ngModel]="store.locale()"
-              (ngModelChange)="store.setLocale($event)"
-            >
-              <hlm-select-trigger class="w-48">
-                <hlm-select-value />
-              </hlm-select-trigger>
-              <hlm-select-content>
-                @for (l of locales; track l.value) {
-                  <hlm-option [value]="l.value">{{ l.label }}</hlm-option>
-                }
-              </hlm-select-content>
-            </brn-select>
-          </div>
+        @case ('users') {
+          <ob-admin-users-list />
+        }
 
-          <div class="flex items-center justify-between gap-2">
-            <div>
-              <span class="text-sm font-medium">{{ 'settings.reducedMotion' | translate }}</span>
-              <p class="text-muted-foreground text-xs">
-                {{ 'settings.reducedMotionHint' | translate }}
-              </p>
-            </div>
-            <hlm-switch
-              [attr.aria-label]="'settings.reducedMotion' | translate"
-              [checked]="store.reducedMotion()"
-              (checkedChange)="store.setReducedMotion($event)"
-            />
-          </div>
+        @case ('backup-restore') {
+          <ob-backup-restore />
+        }
 
-          <div>
-            <button
-              hlmBtn
-              variant="outline"
-              size="sm"
-              (click)="store.reset()"
-            >
-              {{ 'settings.reset' | translate }}
-            </button>
-          </div>
-        </div>
-      </div>
+        @case ('replication') {
+          <ob-replication />
+        }
 
-      <ob-change-password />
-    </div>
+        @case ('audit') {
+          <ob-audit-log />
+        }
+      }
+    </ob-page-layout>
   `,
 })
-export class SettingsComponent {
+export class SettingsComponent implements OnInit {
   protected readonly store = inject(AppearanceStore);
   private readonly pageHeader = inject(PageHeaderService);
+  private readonly auth = inject(AuthService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly activeTab = signal('appearance');
+
+  /** Tabs (EPIC-11): the Admin Users tab is dropped for read-only admins. */
+  protected readonly tabs = computed<PageTab[]>(() => {
+    const base: PageTab[] = [
+      { id: 'appearance', label: 'settings.appearance' },
+      { id: 'keys', label: 'sidebar.storage.keys' },
+      { id: 'users', label: 'sidebar.admin.users' },
+      { id: 'backup-restore', label: 'backupRestore.title' },
+      { id: 'replication', label: 'replication.title' },
+      { id: 'audit', label: 'sidebar.admin.audit' },
+    ];
+    return this.auth.isFullAdmin() ? base : base.filter((t) => t.id !== 'users');
+  });
 
   protected readonly schemes: { value: ColorScheme; label: string; color: string }[] = [
     { value: 'slate', label: 'Slate', color: '#475569' },
@@ -183,7 +261,26 @@ export class SettingsComponent {
   ];
 
   constructor() {
+    // The tabs carry the sections — set the page header once, no action button.
     this.pageHeader.setPageHeader('settings.title', 'settings.subtitle');
     this.pageHeader.hideActionButton();
+  }
+
+  ngOnInit(): void {
+    this.route.queryParamMap.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((q) => {
+      const requested = q.get('tab') ?? 'appearance';
+      // Fall back to the default when the tab is unknown or gated (e.g. a
+      // read-only admin deep-linking `?tab=users`).
+      const allowed = this.tabs().some((t) => t.id === requested);
+      this.activeTab.set(allowed ? requested : 'appearance');
+    });
+  }
+
+  onTab(tab: string): void {
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { tab },
+      queryParamsHandling: 'merge',
+    });
   }
 }

--- a/apps/openbucket-frontend/src/app/users/admin-users-list.component.ts
+++ b/apps/openbucket-frontend/src/app/users/admin-users-list.component.ts
@@ -1,7 +1,6 @@
 import {
   ChangeDetectionStrategy,
   Component,
-  OnDestroy,
   OnInit,
   computed,
   inject,
@@ -22,7 +21,6 @@ import { ConfirmDialogComponent } from '../shared/ui/confirm-dialog.component';
 import { ListStateComponent } from '../shared/ui/list-state.component';
 import { SortHeaderComponent, type SortDir } from '../shared/ui/sort-header.component';
 import { notify } from '../shared/ui/notify';
-import { PageHeaderService } from '../layout/shell/services';
 import { AuthService } from '../auth/auth.service';
 import { AdminUsersSignalStore } from './admin-users.signal-store';
 import { AdminUserCreateDialogComponent } from './admin-user-create-dialog.component';
@@ -56,6 +54,14 @@ import { AdminUserEditDialogComponent } from './admin-user-edit-dialog.component
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="p-6">
+      <div class="mb-4 flex justify-end">
+        <button
+          hlmBtn
+          (click)="createDialog().open()"
+        >
+          {{ 'users.create' | translate }}
+        </button>
+      </div>
       <ob-list-state
         [loading]="store.loading()"
         [error]="store.error()"
@@ -183,9 +189,8 @@ import { AdminUserEditDialogComponent } from './admin-user-edit-dialog.component
     />
   `,
 })
-export class AdminUsersListComponent implements OnInit, OnDestroy {
+export class AdminUsersListComponent implements OnInit {
   protected readonly store = inject(AdminUsersSignalStore);
-  private readonly pageHeader = inject(PageHeaderService);
   private readonly auth = inject(AuthService);
   private readonly i18n = inject(TranslateService);
 
@@ -209,17 +214,8 @@ export class AdminUsersListComponent implements OnInit, OnDestroy {
     );
   });
 
-  constructor() {
-    this.pageHeader.setPageHeader('users.title', 'users.subtitle');
-    this.pageHeader.setActionButton('users.create', () => this.createDialog().open());
-  }
-
   ngOnInit(): void {
     void this.store.refresh();
-  }
-
-  ngOnDestroy(): void {
-    this.pageHeader.hideActionButton();
   }
 
   protected toggleSort(key: 'username'): void {


### PR DESCRIPTION
Moves **Access Keys, Admin Users, Backup & Restore, Replication, Audit Log** — plus the existing **Appearance** — into tabs inside the **Settings** route, and removes them as standalone sidebar items. Frontend-only.

## What changed
- **Settings (`/settings`) is now tabbed** (same `ob-page-layout` + `?tab=` pattern as bucket detail): Appearance · Access Keys · Admin Users · Backup & Restore · Replication · Audit Log.
- The five feature components are now **embeddable** — their own page-header/action wiring was removed; the "New key" / "New user" buttons moved into the tab content.
- **Sidebar** slimmed to Dashboard · Buckets · Search · Settings.
- **Routes** for the five standalone pages removed; internal links (home quick-action, command palette, `g k` shortcut) repointed to `/settings?tab=…`.
- **Role gating preserved:** read-only admins don't see the Admin Users tab, and a deep-link to `?tab=users` falls back to Appearance (server RolesGuard remains authoritative).

## Validation
`nx build`/`lint` for the frontend clean; no dead internal links; conformance/Docker via CI (the SPA bundles into the package).

Release as **alpha.13** after CI.