### PR TITLE
feat: MOUNT_PATH for the standalone image + fix docs admonitions

### DIFF
--- a/apps/docs/docs/concepts/architecture.md
+++ b/apps/docs/docs/concepts/architecture.md
@@ -47,7 +47,7 @@ So the container and the embedded module run **exactly the same code** — the o
 difference is who owns the Node process and where config comes from (environment
 variables for standalone, `OpenBucketModule.forRoot({ … })` in code for embedded).
 
-:::info No horizontal scale-out (yet)
+:::info[No horizontal scale-out (yet)]
 OpenBucket is a **single-node** store: SQLite plus a local blob tree assume one
 writer. You scale it **up** (bigger disk, more CPU) and make it **durable**
 (backups, async replication to an S3 target), not **out** across nodes. See

--- a/apps/docs/docs/concepts/durability.md
+++ b/apps/docs/docs/concepts/durability.md
@@ -26,7 +26,7 @@ A crash at any point leaves either the **old** object or the **new** one — nev
 torn half-written blob. The same tmp→fsync→rename shape backs multipart parts,
 multipart compose, backups, and rehydrated (tiered) reads.
 
-:::warning Keep `tmp/` and `blobs/` on one filesystem
+:::warning[Keep `tmp/` and `blobs/` on one filesystem]
 `rename(2)` is atomic **only within a single filesystem**. If `DATA_DIR/tmp` and
 `DATA_DIR/blobs` land on different mounts, Node returns `EXDEV` and OpenBucket
 falls back to a (non-atomic) copy + unlink, logging a loud warning. Mount all of
@@ -104,7 +104,7 @@ OB_REPLICATION_SECRET_ACCESS_KEY=…
 # Omit OB_REPLICATION_ENDPOINT for real AWS S3; set it for R2/B2/MinIO.
 ```
 
-:::note Plaintext over the wire
+:::note[Plaintext over the wire]
 The worker sends object **plaintext** (SSE is decrypted before sending), so an
 `http://` endpoint leaks object contents and warns at boot. Prefer `https://`
 unless the target is MinIO on a trusted LAN. Credentials are never logged.
@@ -145,7 +145,7 @@ sidecar recording size, object count, and SHA-256. **Union retention** means
 keep-last-N is a hard floor and max-age can never delete a fresh snapshot. A
 pre-flight free-space guard skips a cycle rather than fill the disk.
 
-:::warning Snapshots contain plaintext object bytes
+:::warning[Snapshots contain plaintext object bytes]
 A backup archive holds **decrypted** object bytes (same posture as replication),
 so snapshot files are `0o600` under a `0o700` directory. Treat the backup volume
 with the same trust boundary as `DATA_DIR`.

--- a/apps/docs/docs/concepts/security-model.md
+++ b/apps/docs/docs/concepts/security-model.md
@@ -48,7 +48,7 @@ The guard:
   form (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER`) is rejected with a clear
   `InvalidArgument`.
 
-:::note Path-style only
+:::note[Path-style only]
 OpenBucket addresses buckets **path-style** (`host/bucket/key`), never
 virtual-host style. Configure your SDK with `forcePathStyle: true` and a region
 that matches `OPENBUCKET_REGION` (default `us-east-1`).
@@ -98,7 +98,7 @@ conditions — `Bool aws:SecureTransport` and `IpAddress`/`NotIpAddress aws:Sour
 — and **fails closed**: an unknown condition operator satisfies a `Deny` but never
 grants an `Allow`.
 
-:::tip Inspect before you ship
+:::tip[Inspect before you ship]
 Before handing a scoped key to a tenant, call `getKeyEffectivePermissions(id)` for
 an allow/deny matrix, or `simulateKeyAction(id, { action, resource })` for a single
 decision — both run through the **same** evaluator the live request path uses, so
@@ -157,7 +157,7 @@ The 32-byte key-encryption key (KEK) that wraps sub-key secrets is **HKDF-SHA256
 derived** from `KEY_ENCRYPTION_SECRET` when set, otherwise from
 `ROOT_SECRET_ACCESS_KEY`.
 
-:::warning Set `KEY_ENCRYPTION_SECRET` up front
+:::warning[Set `KEY_ENCRYPTION_SECRET` up front]
 If you rotate `ROOT_SECRET_ACCESS_KEY` **without** having set a dedicated
 `KEY_ENCRYPTION_SECRET`, the KEK changes and every existing sub-key secret becomes
 undecryptable — those keys must be re-minted. Set a strong `KEY_ENCRYPTION_SECRET`

--- a/apps/docs/docs/concepts/storage-layout.md
+++ b/apps/docs/docs/concepts/storage-layout.md
@@ -36,7 +36,7 @@ DATA_DIR/
 └── backups/                 scheduled .zip snapshots (default location)
 ```
 
-:::tip Back up the whole directory
+:::tip[Back up the whole directory]
 `DATA_DIR` is the entire state of the instance — metadata **and** bytes. A
 filesystem-level snapshot of it (with the process stopped, or via the built-in
 backup) is a complete point-in-time copy. Don't try to back up `blobs/` without
@@ -84,7 +84,7 @@ The encoding round-trips: `decodeKey` reverses it. Decoding is only used for
 diagnostics and the orphan-blob recovery scan — the hot path always reads the raw
 key from SQLite.
 
-:::note Why not just base64 the key?
+:::note[Why not just base64 the key?]
 The path-mirroring encoding keeps the on-disk tree **human-legible** and preserves
 the folder structure, so an operator browsing `blobs/` sees something close to the
 logical layout — while still being safe against traversal, hidden files, and
@@ -115,7 +115,7 @@ When `OPENBUCKET_SSE_KEY` is unset, OpenBucket generates a random 32-byte SSE-S3
 key on first boot and persists it to `<DATA_DIR>/sse.key` (mode `0600`). Each
 encrypted object stores its own random IV in metadata; the key is instance-wide.
 
-:::warning `sse.key` is break-glass material
+:::warning[`sse.key` is break-glass material]
 Losing this file makes every SSE-encrypted object permanently unreadable. Back it
 up with your other secrets — and prefer delivering it via `OPENBUCKET_SSE_KEY`
 from a secrets manager over relying on the generated file. See the

--- a/apps/docs/docs/getting-started/core-concepts.md
+++ b/apps/docs/docs/getting-started/core-concepts.md
@@ -25,7 +25,7 @@ const { contents, commonPrefixes } = await ob.listObjects('my-bucket', {
 });
 ```
 
-:::note Keys are stable identity
+:::note[Keys are stable identity]
 An object is identified by `{ bucket, key }`. That pair is what you persist in your own database — never a presigned URL, which expires. Mint a fresh URL from the key whenever you need one (see [Your first upload](./first-upload.md)).
 :::
 
@@ -47,7 +47,7 @@ Pick standalone for a drop-in S3 service; pick embedded when you want an object 
 
 Because everything sits under `mountPath`, OpenBucket's greedy S3 routes (`:bucket/:key`) never shadow a host app's own routes, and its exception filter only renders errors for requests under the prefix.
 
-:::warning Path-style addressing only
+:::warning[Path-style addressing only]
 OpenBucket addresses buckets as `<endpoint>/<bucket>/<key>`, never `<bucket>.<host>`. Virtual-host-style addressing is not supported, so always configure your client for path-style (`forcePathStyle: true` in the AWS SDK).
 :::
 
@@ -78,7 +78,7 @@ These sign in to the **admin console and JSON API** — a different credential e
 - The first-run bootstrap admin (`ADMIN_USERNAME` / `ADMIN_PASSWORD_HASH`) is a full admin. Manage additional admins from the console or `POST /api/admin/users`.
 - Enforcement is server-side and default-deny by HTTP method, read fresh from the DB on every request, so a demotion takes effect immediately.
 
-:::info Two roles, same word, different worlds
+:::info[Two roles, same word, different worlds]
 A minted **S3 access key** carries `role: 'scoped'` or `role: 'root'` — that labels a *data-plane* key's reach. An **admin user** carries `role: 'admin'` or `role: 'readonly'` — that governs the *admin console*. They are orthogonal: an S3 key can't sign into the console, and an admin login can't sign an S3 request.
 :::
 

--- a/apps/docs/docs/getting-started/first-upload.md
+++ b/apps/docs/docs/getting-started/first-upload.md
@@ -45,7 +45,7 @@ export class FilesController {
 
 That's the whole upload path. Post a `multipart/form-data` request with a `file` part and the bytes land in the `uploads` bucket, content-sniffed and size-checked.
 
-:::tip Why `contentType` is trustworthy
+:::tip[Why `contentType` is trustworthy]
 The engine sniffs the type from the body's magic bytes and the **sniffed type wins** over whatever the client declared — so a "PNG" that's really HTML is caught and rejected, not stored. `file.contentType` is the resolved, verified type.
 :::
 
@@ -100,7 +100,7 @@ export class UploadsBootstrap implements OnApplicationBootstrap {
 }
 ```
 
-:::note Why the exception filter matters
+:::note[Why the exception filter matters]
 `UploadValidationExceptionFilter` is scoped to `UploadValidationError`, so it turns a too-large / disallowed-type / active-content upload into a clean `400` — but it deliberately does **not** swallow an S3 error like `NoSuchBucketError`. If you skip the bootstrap above, an upload to a missing bucket surfaces as a real error, not a silent `400`.
 :::
 
@@ -175,7 +175,7 @@ export class FilesController {
 
 The built-in `keyStrategy` values are `'uuid'`, `'uuid-flat'`, `'sha256'` (content-addressed), and `'original'` (sanitized filename). You can also pass a `(ctx) => string` function — its result is always run through the anti-traversal `assertSafeKey` gate.
 
-:::info `putObject` is the raw primitive
+:::info[`putObject` is the raw primitive]
 Want no sniffing or validation and to pick the key entirely yourself? `this.ob.putObject(bucket, key, body, { contentType })` writes a `Buffer`, string, or `Readable` directly. `uploadFrom` is sugar on top of it.
 :::
 
@@ -190,7 +190,7 @@ return files.map((f) => this.toDto(f)); // each gets a fresh 1-hour URL
 
 `presignGetUrl` is pure crypto over your root credentials — no DB or filesystem access. `expiresIn` is in seconds and caps at 7 days. `baseUrl` is your public origin (scheme + host); OpenBucket appends the `mountPath` and object path for you.
 
-:::warning Store the key, not the URL
+:::warning[Store the key, not the URL]
 Presigned URLs expire, so persisting one as a column means dead links later. The robust default is **store `{ bucket, key }`, presign on read**. If you truly want a URL column, either re-mint it periodically with a longer `expiresIn`, or — for a bucket you deliberately make public with an anonymous-GET policy — store the stable path-style URL `` `${PUBLIC_ORIGIN}${mountPath}/${bucket}/${key}` ``.
 :::
 

--- a/apps/docs/docs/getting-started/quickstart-docker.md
+++ b/apps/docs/docs/getting-started/quickstart-docker.md
@@ -25,7 +25,7 @@ docker compose up --build
 
 When the logs settle, OpenBucket is listening on **http://localhost:9000**. Open the admin console at **http://localhost:9000/admin** and sign in with `admin` and the password you just hashed.
 
-:::tip What each command did
+:::tip[What each command did]
 `hash-password.mjs` prints an argon2id hash to stdout — the app stores only the hash, never your plaintext password. `docker compose up` builds the image from the repo `Dockerfile` and mounts a named volume (`openbucket-data`) at `/data`, so your buckets and objects survive a restart.
 :::
 
@@ -66,7 +66,7 @@ Everything is **path-style** and served from the one port:
 | Admin JSON API | `http://localhost:9000/api/admin` |
 | Health / readiness | `http://localhost:9000/api/admin/health`, `/api/admin/ready` |
 
-:::note Path-style only
+:::note[Path-style only]
 OpenBucket addresses buckets as `http://localhost:9000/my-bucket/key` — never `http://my-bucket.localhost:9000`. Virtual-host-style addressing is not supported, so always set path-style / `forcePathStyle: true` in your client.
 :::
 
@@ -110,7 +110,7 @@ await s3.send(
 
 Streaming PUT/GET, multipart uploads, presigned URLs, and range reads all behave exactly as they do against AWS S3.
 
-:::warning Keep your secrets out of version control
+:::warning[Keep your secrets out of version control]
 `.env` holds real credentials — it should already be gitignored. Never commit it, and prefer a secrets manager over inline env vars for production.
 :::
 

--- a/apps/docs/docs/getting-started/quickstart-embed.md
+++ b/apps/docs/docs/getting-started/quickstart-embed.md
@@ -45,7 +45,7 @@ export class AppModule {}
 
 Start your app and point any S3 client at `http://your-host:3000/storage` (path-style, root credentials). The admin console is at `http://your-host:3000/storage/admin`.
 
-:::tip Generating the argon2id hash
+:::tip[Generating the argon2id hash]
 `admin.passwordHash` is an argon2id hash, never a plaintext password. Generate one with the repo helper: `node scripts/hash-password.mjs 'your-admin-password'`. `jwtSecret` and `rootCredentials.secretAccessKey` must each be at least 32 chars, and `passwordHash` must be a real argon2id string — the module validates all of this at boot and throws if it's wrong.
 :::
 
@@ -62,7 +62,7 @@ Everything lives under `mountPath`, so OpenBucket's greedy S3 routes never shado
 
 Your own routes are untouched, and OpenBucket's exception filter only renders errors for requests under `mountPath`.
 
-:::warning Don't body-parse the mount
+:::warning[Don't body-parse the mount]
 The S3 protocol needs raw, unbuffered request bodies. Do **not** apply a global JSON/body parser to `mountPath` in your host app. Also call `app.enableShutdownHooks()` in your bootstrap so OpenBucket's in-flight drain runs on `SIGTERM`.
 :::
 
@@ -127,7 +127,7 @@ OpenBucketModule.forRoot({
 });
 ```
 
-:::note Partial admin blocks are rejected
+:::note[Partial admin blocks are rejected]
 A present-but-partial `admin` block fails at startup — it would otherwise sign JWTs with an empty secret. Supply all three of `username`, `passwordHash`, and `jwtSecret`, or omit the block entirely.
 :::
 
@@ -153,7 +153,7 @@ export class FilesService {
 }
 ```
 
-:::info Requirements
+:::info[Requirements]
 `@openbucket/nestjs` targets **Node 20.19+** and NestJS 11 (`@nestjs/common`, `@nestjs/core`, and `@nestjs/platform-express` are peer dependencies).
 :::
 

--- a/apps/docs/docs/guides/admin-console.md
+++ b/apps/docs/docs/guides/admin-console.md
@@ -19,7 +19,7 @@ Embedded:    http://<host><mountPath>/admin     (e.g. /storage/admin)
 
 Sign in at `/login` with your admin username and password (`ADMIN_USERNAME` defaults to `admin`). Everything past login is behind an auth guard; the only routes outside the app shell are `/login` and `/force-rotate` (shown when a password rotation is required). All feature screens are lazy-loaded, so the first paint is fast.
 
-:::note The console needs the admin surface
+:::note[The console needs the admin surface]
 The SPA is wired only when you configure the `admin` block (with `serveUi: true`) — a headless, S3-only store has no console. See [the module reference](../reference/nestjs-module.md).
 :::
 
@@ -88,7 +88,7 @@ Surfaces the background integrity scrubber: scanned / ok / corrupt / repaired st
 
 A durable, queryable record of **every state-changing admin action**, newest first, keyset-paged with bounded retention.
 
-:::tip Read-only admins see everything
+:::tip[Read-only admins see everything]
 A read-only admin can open every one of these tabs and read the data; the server default-denies any change by HTTP method, read fresh from the DB on each request, so a demotion takes effect immediately.
 :::
 

--- a/apps/docs/docs/guides/backup-and-restore.md
+++ b/apps/docs/docs/guides/backup-and-restore.md
@@ -56,7 +56,7 @@ curl -sS -X POST http://localhost:9000/api/admin/buckets/acme-data/restore \
 Both return a small JSON summary — `bucketsRestored` / `objectsRestored` for the
 instance route, `objectsRestored` for the bucket route.
 
-:::warning Restore is a reset, not a merge
+:::warning[Restore is a reset, not a merge]
 Restoring the instance **resets the instance**; restoring a bucket **resets that
 bucket** to exactly the snapshot's contents. It is not additive — anything not in
 the archive is gone. Restore into a fresh instance, or be certain you mean to
@@ -141,13 +141,13 @@ copy each finished snapshot to your configured [replication
 target](./replication-and-tiering.md) under a reserved prefix — so a lost data
 volume doesn't take your backups with it.
 
-:::note Enable replication first
+:::note[Enable replication first]
 If you set the push flag but replication is off, the runner logs a boot-time
 warning and writes snapshots locally only — the push is a no-op until you
 configure `OB_REPLICATION_*`.
 :::
 
-:::warning Snapshots are plaintext
+:::warning[Snapshots are plaintext]
 A `.zip` contains **decrypted** object bytes (SSE-S3 is a rest-encryption of the
 local blobs, not the archive). Snapshots are written `0o600` inside a `0o700`
 directory, but the archive itself inherits your data volume's trust boundary —

--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -23,7 +23,7 @@ npx openbucket buckets ls
 
 That's it. The password is exchanged for a short-lived bearer token in memory, the request goes out, and you get a table back.
 
-:::note The endpoint is your admin base URL
+:::note[The endpoint is your admin base URL]
 `OPENBUCKET_ENDPOINT` is the host **plus `mountPath`** — the same base the admin API lives under (`<endpoint>/api/admin/*`). Standalone at the root is `http://your-host:9000`; embedded is `http://your-host/storage`. The default `http://127.0.0.1:3900` matches a local dev server.
 :::
 
@@ -40,7 +40,7 @@ Everything is set by env var or flag, with **flag over env** precedence:
 
 **The password is never a flag.** It's read only from `OPENBUCKET_PASSWORD` or an interactive, non-echoing prompt — so it can't land on `argv` or in `ps` output. Set `OPENBUCKET_TOKEN` to reuse an existing bearer token and skip login entirely (handy in CI, where there's no TTY to prompt).
 
-:::warning Plaintext credentials
+:::warning[Plaintext credentials]
 The CLI refuses to send credentials over plain `http://` to a **non-loopback** host. Use `https`, or — if you really mean it on a trusted network — pass `--insecure`.
 :::
 
@@ -84,7 +84,7 @@ scope           prefix:reports/2026/
 
 Omit `--scope` for an unrestricted (root-role) key. The scope shorthand is parsed and validated client-side, so a malformed shape fails fast without hitting the API.
 
-:::tip Capture the secret in CI
+:::tip[Capture the secret in CI]
 Use `--json` and read the field: `openbucket keys create --label ci --json | jq -r .secretAccessKey`. The redactor still keeps the secret out of every error path — it only ever appears on this one success line.
 :::
 
@@ -124,7 +124,7 @@ Scriptable and stable:
 
 Data goes to **stdout**; human-readable errors go to **stderr**, run through a central redactor that strips bearer tokens, JWTs, and `secretAccessKey` / `password` values before anything is printed. A `429` is surfaced but never auto-retried (that would only deepen the login throttle).
 
-:::note Zero dependencies
+:::note[Zero dependencies]
 The CLI is built entirely on Node built-ins (`fetch`, `parseArgs`, `readline`) — installing `@openbucket/nestjs` drags nothing extra into your tree for it.
 :::
 

--- a/apps/docs/docs/guides/events-and-webhooks.md
+++ b/apps/docs/docs/guides/events-and-webhooks.md
@@ -34,7 +34,7 @@ Register the listener class as a provider in your module and you're done. Three 
 | `@OnObjectDeleted()` | `DeleteObject` / bulk delete / delete-marker |
 | `@OnMultipartCompleted()` | `CompleteMultipartUpload` |
 
-:::warning In-process handlers run with your app's full privileges
+:::warning[In-process handlers run with your app's full privileges]
 OpenBucket does **not** sandbox these — they are your code. They are dispatched fire-and-forget (never awaited), so a handler that throws or hangs can't stall or fail the write. But that also means a handler failure is logged and dropped, not retried. For guaranteed delivery, use webhooks.
 :::
 
@@ -87,7 +87,7 @@ WEBHOOK_POLL_MS=15000
 
 Webhooks are **off** unless a `url` (or `WEBHOOK_URL`) is set. When present, the outbox and the delivery runner turn on; in-process handlers keep working either way.
 
-:::note Config is fail-closed at boot
+:::note[Config is fail-closed at boot]
 The URL must be `https` (or a loopback host), and the secret must be at least 32 characters, or the app refuses to boot. This is deliberate — no weak-secret or plaintext webhook can slip into production.
 :::
 
@@ -128,7 +128,7 @@ function verify(rawBody: string, header: string, secret: string): boolean {
 }
 ```
 
-:::warning Sign the raw body, and dedupe on the delivery id
+:::warning[Sign the raw body, and dedupe on the delivery id]
 Compute the HMAC over the **unparsed** request bytes — re-serializing the JSON will change the bytes and break the signature. Because delivery is **at-least-once** (a crash after your `2xx` but before the row is marked delivered re-sends), your receiver must be idempotent: dedupe on the `X-OpenBucket-Delivery` id.
 :::
 
@@ -136,7 +136,7 @@ Compute the HMAC over the **unparsed** request bytes — re-serializing the JSON
 
 A non-`2xx` response, a network error, or a timeout is retried with full-jitter exponential backoff (base 2s, capped at 1h). After `maxAttempts` the row is dead-lettered to a `failed` state and no longer retried. Terminal rows (delivered or failed) are pruned after 7 days. Events are processed in due-time order — **best-effort, not strictly per-key** — so don't rely on strict ordering.
 
-:::info SSRF-safe by construction
+:::info[SSRF-safe by construction]
 The webhook URL is operator-configured (never tenant-controlled) and validated `https`/loopback at config time. Redirects are **not** followed — any `3xx` is treated as a failure. The response body is discarded (only the status matters), and the signing secret is never logged.
 :::
 

--- a/apps/docs/docs/guides/file-uploads.md
+++ b/apps/docs/docs/guides/file-uploads.md
@@ -89,7 +89,7 @@ validate: {
 
 A rejected upload throws `UploadValidationError` with a stable `code` (`too_large`, `active_content`, `type_not_allowed`, `no_content_type`, `invalid_key`) and a `statusHint` of `400`.
 
-:::warning Map rejections to HTTP 400
+:::warning[Map rejections to HTTP 400]
 `UploadValidationError` is not an HTTP exception. Catch it and map it, or use the ready-made filter (see the multer section):
 
 ```ts
@@ -118,7 +118,7 @@ keyStrategy: (ctx) => `tenant/${tenantId}/${randomUUID()}${ctx.ext}`,
 
 The `sha256` strategy is idempotent: re-uploading identical bytes lands on the same key and returns the existing object. Give an explicit `key` instead of a strategy to write to a fixed path (it wins over `keyStrategy`).
 
-:::info Every key is sanitized
+:::info[Every key is sanitized]
 Custom key functions and the `'original'` strategy pass through `assertSafeKey`, which rejects empty keys, a leading `/`, `.`/`..` traversal segments, control characters, and over-long keys/segments. A raw client filename is never used verbatim.
 :::
 
@@ -203,7 +203,7 @@ export function OpenBucketFileInterceptor(
 
 The engine's `bucket`, `key`, and `validate` options can each be a static value or a `(req, file) => …` function, so you can derive the bucket or key per request. If a later part of the request fails, multer calls the engine's rollback, which deletes the already-committed object.
 
-:::tip Pair the two size caps
+:::tip[Pair the two size caps]
 Set `validate.maxBytes` (enforced mid-write, after busboy) alongside multer's own `limits.fileSize` (an early busboy-layer cut-off) for defense in depth.
 :::
 

--- a/apps/docs/docs/guides/image-transforms.md
+++ b/apps/docs/docs/guides/image-transforms.md
@@ -18,7 +18,7 @@ GET /uploads/photo.jpg?w=400&format=webp
 
 That returns `photo.jpg` resized to 400px wide and re-encoded as WebP. The result is content-addressed and served with `Cache-Control: public, max-age=31536000, immutable`, so browsers and CDNs cache it indefinitely.
 
-:::info Transforms run on the GET route
+:::info[Transforms run on the GET route]
 The transform happens on an authorized S3 GET, not through `getObjectStream`. The simplest way to use it from an `<img>` tag is a public-read bucket — see [gotchas](#gotchas) below and [Sharing files](./sharing-files.md#permanent-links-public-buckets).
 :::
 
@@ -76,13 +76,13 @@ Transforms are **on by default** and every knob is a safety bound. In the standa
 
 Defense in depth is layered: the param parser bounds the canvas before decode, an input-byte cap refuses oversized sources, `limitInputPixels` stops decompression bombs, a counting semaphore caps parallelism, and the per-IP request throttle sits in front of all of it.
 
-:::warning Bad input is always a 400, never a 500
+:::warning[Bad input is always a 400, never a 500]
 An out-of-range dimension, an unknown format, a too-large source, or an undecodable image all return an S3-style `400` — never a `500` or an OOM. Authorization is unchanged: a transform request runs through the same `s3:GetObject` checks as a plain GET.
 :::
 
 ## Gotchas
 
-:::warning You can't append params to a presigned URL
+:::warning[You can't append params to a presigned URL]
 A presigned URL signs its entire query string. Tacking `?w=400` onto a minted presigned GET breaks the signature and the request is rejected. To use transforms, either:
 
 - serve from a **public-read bucket** so an anonymous `<img src>` GET works directly, or
@@ -91,7 +91,7 @@ A presigned URL signs its entire query string. Tacking `?w=400` onto a minted pr
 The public-bucket route is the usual choice for `<img>` tags. See [Sharing files](./sharing-files.md#permanent-links-public-buckets).
 :::
 
-:::note Non-images just pass through
+:::note[Non-images just pass through]
 If the object isn't an allow-listed raster type (or is an SVG), the transform params are ignored and the original bytes are served with the usual safe response headers. No error.
 :::
 

--- a/apps/docs/docs/guides/multi-tenancy.md
+++ b/apps/docs/docs/guides/multi-tenancy.md
@@ -102,7 +102,7 @@ The semantics are AWS-aligned: a matching `Deny` always wins, else a matching
 `Allow` grants, else the default fallback applies. An operation the guard can't
 map to an `s3:*` action **fails closed** for a scoped key.
 
-:::info Root stays unrestricted
+:::info[Root stays unrestricted]
 Root credentials are never scope-checked. Their request path is byte-identical to
 a store with no scoping at all — a scoped key is a strictly narrower grant layered
 on top.
@@ -185,13 +185,13 @@ actions a read-only admin can still perform: changing their own password
 (`settings/change-password`) and logging out (`auth/logout`). Managing admin
 users is itself full-admin-only.
 
-:::warning The scope is fixed at mint time
+:::warning[The scope is fixed at mint time]
 A key's scope is compiled and stored when you create the key; there's no
 "edit scope" endpoint. To change a tenant's reach, mint a new scoped key and
 revoke the old one. `PATCH` only toggles `disabled` / `label`.
 :::
 
-:::note One bucket, or one prefix
+:::note[One bucket, or one prefix]
 A prefix scope pins a key to a single bucket (and optional key prefix). To give a
 tenant several buckets, mint several keys, or author an inline `"kind": "policy"`
 scope whose statements list each bucket's ARN.

--- a/apps/docs/docs/guides/observability.md
+++ b/apps/docs/docs/guides/observability.md
@@ -41,7 +41,7 @@ curl http://localhost:3000/storage/metrics
 
 You get standard Prometheus text exposition (`Content-Type: text/plain; version=0.0.4`) with every `openbucket_*` family below.
 
-:::note Where the endpoint lives
+:::note[Where the endpoint lives]
 The route is always `<mountPath>/metrics`. Standalone mounts at the root, so it is `/metrics`. Embedded, it sits under your `mountPath` (default `/storage`) — e.g. `/storage/metrics`.
 :::
 
@@ -72,7 +72,7 @@ Then scrape with the bearer header:
 curl -H "Authorization: Bearer $METRICS_TOKEN" http://localhost:9000/metrics
 ```
 
-:::tip The token is never logged
+:::tip[The token is never logged]
 The bearer header is redacted by the same pino redaction path as every other credential — it never lands in a log line, an error message, or a span attribute.
 :::
 
@@ -126,7 +126,7 @@ scrape_configs:
       - targets: ['openbucket:9000']
 ```
 
-:::warning Rate limits apply
+:::warning[Rate limits apply]
 The scrape is subject to the admin throttler (100 requests/min). A 15–30s scrape interval is plenty and stays well under the bound.
 :::
 
@@ -196,7 +196,7 @@ Even with the api installed, spans do nothing until an SDK registers a global tr
 
 OpenBucket wraps request handling in a span named against the `openbucket` tracer. Span attributes hold to the **same redaction posture as logs**: only bounded, non-sensitive dimensions (`method`, `route_class`, `surface`) and the final `http.status_code` — never the URL, object key, bucket, or any header or credential.
 
-:::info Why the eval require
+:::info[Why the eval require]
 The library resolves `@opentelemetry/api` dynamically at runtime so neither `tsc` nor a host webpack bundle needs the (possibly absent) package. Hosts that never opt in pay nothing and the bundle builds and boots without OTel installed.
 :::
 

--- a/apps/docs/docs/guides/replication-and-tiering.md
+++ b/apps/docs/docs/guides/replication-and-tiering.md
@@ -11,7 +11,7 @@ Cloudflare R2, Backblaze B2, MinIO), and — optionally — offload cold objects
 that same target while still serving them transparently on read. Both features
 share one remote target and are off by default.
 
-:::info One-way, not a cluster
+:::info[One-way, not a cluster]
 Replication is **asynchronous, one-way mirroring** of your visible object state
 to a remote target. It is not multi-primary clustering, not a quorum, and not a
 read replica you can serve from. OpenBucket stays the single source of truth; the
@@ -76,7 +76,7 @@ Tuning knobs: `OB_REPLICATION_DRAIN_INTERVAL_MS` (default 5000),
 `OB_REPLICATION_LARGE_OBJECT_THRESHOLD_BYTES` (switch to multipart streaming above
 this size, default 64 MiB).
 
-:::warning The wire carries plaintext
+:::warning[The wire carries plaintext]
 The worker sends object **plaintext** (SSE-S3 is decrypted before the object
 leaves the box). Use an `https` endpoint — a plaintext `http://` endpoint logs a
 boot-time warning because replicated bytes would traverse the network
@@ -146,14 +146,14 @@ local free space are bounded so a hot key — or a lying remote — can't exhaus
 box. Objects at or under `OPENBUCKET_TIER_INLINE_MAX_BYTES` are proxied inline;
 larger objects are served via a short-lived presigned redirect to the remote.
 
-:::note Tiering is env-only and needs a remote
+:::note[Tiering is env-only and needs a remote]
 There's no `forRoot` option for tiering — configure it with the `OPENBUCKET_TIER_*`
 environment variables. Tiering reuses the replication target, so a remote must be
 configured; with no remote the feature reports disabled and both offload and
 read-through are inert (a single-node install behaves exactly as before).
 :::
 
-:::warning Cold reads are slower and metered
+:::warning[Cold reads are slower and metered]
 A read of a tiered object pays a remote round-trip (and, for `GLACIER` /
 `DEEP_ARCHIVE`-class targets, whatever retrieval latency and cost that tier
 imposes). Tier objects you rarely read — not your hot path.

--- a/apps/docs/docs/guides/securing-openbucket.md
+++ b/apps/docs/docs/guides/securing-openbucket.md
@@ -38,7 +38,7 @@ Generate real ones:
 openssl rand -base64 48
 ```
 
-:::tip Set KEY_ENCRYPTION_SECRET before you mint scoped keys
+:::tip[Set KEY_ENCRYPTION_SECRET before you mint scoped keys]
 Scoped sub-key secrets are encrypted at rest with the instance KEK derived from
 `KEY_ENCRYPTION_SECRET`. Set it early — rotating it later invalidates existing
 encrypted sub-key secrets.
@@ -105,7 +105,7 @@ sending an `X-Forwarded-Proto` header from off-box. Terminate TLS in nginx /
 Caddy / your load balancer on the same host (or a trusted network path) and
 forward to OpenBucket over loopback.
 
-:::warning Don't widen the proxy trust blindly
+:::warning[Don't widen the proxy trust blindly]
 The `loopback`-only trust is deliberate. If you front OpenBucket from a proxy on a
 different host, make sure the network path is trusted before relying on
 `aws:SecureTransport` — a spoofable forwarded-proto header would let a plaintext
@@ -162,7 +162,7 @@ encryption of secrets, a restrictive CSP, and fail-closed authorization. It is a
 solid baseline for a self-hosted store — not a substitute for your own threat
 model, network segmentation, and OS-level hardening of the data volume.
 
-:::note Lock down the observability surface too
+:::note[Lock down the observability surface too]
 Leave `METRICS_MODE=off` unless you need a Prometheus scrape; when you do, prefer
 `token` mode with a strong `METRICS_TOKEN` over `public`. The `/metrics` endpoint
 never emits raw URLs, keys, or IPs, but the token keeps casual scrapers out.

--- a/apps/docs/docs/guides/sharing-files.md
+++ b/apps/docs/docs/guides/sharing-files.md
@@ -36,7 +36,7 @@ interface PresignOptions {
 - `expiresIn` is clamped to `[1, 7 days]` — 7 days is the S3 maximum for a presigned URL.
 - `baseUrl` is the origin your clients actually reach the store at (scheme + host); the bucket, key, and configured `mountPath` are appended for you. It defaults to `` `https://${endpoint}` `` when the module's `endpoint` option is set; otherwise `baseUrl` is required (a call without either throws).
 
-:::note Store the key, presign on read
+:::note[Store the key, presign on read]
 Persist the stable `{ bucket, key }` in your database — never a signed URL, which expires. Mint a fresh URL each time you read the row. It's a pure hash, so there's no cost to re-minting, and nothing ever goes stale.
 :::
 
@@ -89,7 +89,7 @@ await fetch(url, { method: 'POST', body: form });
 | `successActionStatus` / `successActionRedirect` | The `2xx` status or redirect the browser gets on success. |
 | `conditions` | Raw extra policy conditions (an escape hatch). |
 
-:::info Every POST token is size-capped
+:::info[Every POST token is size-capped]
 If you omit `contentLengthRange`, OpenBucket injects one defaulted to the server's `maxObjectSizeMb` cap, so a minted token can never authorize an object larger than the server allows. The size range is re-enforced on the streamed bytes on the wire.
 :::
 
@@ -119,7 +119,7 @@ https://files.example.com/<mountPath>/my-bucket/<key>
 
 (In the standalone app `mountPath` is empty, so the URL is `https://host/my-bucket/<key>`.) These URLs are also what let [image transforms](./image-transforms.md) work from a plain `<img>` tag.
 
-:::warning A public bucket is public
+:::warning[A public bucket is public]
 Anonymous `s3:GetObject` means every object in the bucket is world-readable — put only assets you're happy to expose there. For anything private, use the **store the key, presign on read** pattern instead. And remember: a presigned URL signs its full query string, so you can't append extra params (like transform `?w=`) to one after minting.
 :::
 

--- a/apps/docs/docs/intro.md
+++ b/apps/docs/docs/intro.md
@@ -24,7 +24,7 @@ It comes in two shapes from one codebase:
   (S3 + admin API + admin console) **inside your own NestJS app**.
   → [**Embed it in NestJS**](./getting-started/quickstart-embed.md)
 
-:::tip New here? Store your first file in 5 minutes.
+:::tip[New here? Store your first file in 5 minutes.]
 The [**first upload**](./getting-started/first-upload.md) tutorial takes you from
 zero to "an uploaded file with a shareable URL" — the thing most apps actually need.
 :::
@@ -61,13 +61,13 @@ The pitch is simple: **it's the file backend for your app.** Because it can run
 | Learn how it works | [Concepts](./concepts/architecture.md) & the [whitepaper](./whitepaper/00-front-matter.md) |
 | Run it in production | [Operations](./operations/deployment.md) — deploy, monitor, upgrade |
 
-:::note Status
+:::note[Status]
 OpenBucket is **pre-1.0** and under active development. The S3 surface and admin
 console are feature-complete and tested; APIs may still change before 1.0. The
 library publishes to the npm **`next`** dist-tag — `npm install @openbucket/nestjs@next`.
 :::
 
-:::info Trademark
+:::info[Trademark]
 OpenBucket is an independent project and is not affiliated with or endorsed by
 Amazon Web Services. "Amazon S3" and "AWS" are trademarks of Amazon.com, Inc.
 "S3-compatible" describes wire-protocol compatibility only.

--- a/apps/docs/docs/operations/deployment.md
+++ b/apps/docs/docs/operations/deployment.md
@@ -54,7 +54,7 @@ OpenBucket now listens on **`http://localhost:9000`**:
 - **Admin API** — `http://localhost:9000/api/admin`
 - **Health / readiness** — `/api/admin/health`, `/api/admin/ready`
 
-:::note Where the image comes from
+:::note[Where the image comes from]
 The standalone server image is published to **`ghcr.io/<owner>/openbucket`** on
 every `v*` release tag, with `:latest`, `:{major}.{minor}`, and exact `:{version}`
 tags (plus `linux/amd64` and `linux/arm64`). Pin an exact version in production;
@@ -90,7 +90,7 @@ The full, commented list lives in `.env.example` at the repo root (webhooks,
 replication, tiering, backups, metrics, analytics, and the DoS-guard limits). See
 the [configuration reference](../reference/nestjs-module.md) for every key.
 
-:::warning Weak secrets fail the boot, on purpose
+:::warning[Weak secrets fail the boot, on purpose]
 A short, all-same-character, or known-placeholder value for `JWT_SECRET` /
 `ROOT_SECRET_ACCESS_KEY` is rejected at startup (not a warning — a hard refusal).
 Generate real random values.
@@ -142,7 +142,7 @@ server {
 Set `OPENBUCKET_ENDPOINT=storage.example.com` so the store reports a DNS-safe
 public hostname for endpoint discovery.
 
-:::info Embedding under a path prefix
+:::info[Embedding under a path prefix]
 When you embed `@openbucket/nestjs` instead of running the container, everything
 mounts under `mountPath` (default `/storage`) — the S3 endpoint is
 `http(s)://<host>/storage`, the admin API is `<mountPath>/api/admin`, and the

--- a/apps/docs/docs/operations/deployment.md
+++ b/apps/docs/docs/operations/deployment.md
@@ -150,6 +150,48 @@ console is `<mountPath>/admin`. Your proxy just needs to forward that path prefi
 to your app. See the [NestJS module reference](../reference/nestjs-module.md).
 :::
 
+## Running behind a reverse proxy at a subpath
+
+To expose OpenBucket at a **subpath** — `https://example.com/storage/…` instead
+of a dedicated host or subdomain — set [`MOUNT_PATH`](../reference/configuration.md)
+on the container. Every surface moves under the prefix in lockstep: S3 becomes
+`https://example.com/storage/<bucket>/<key>`, the admin API
+`https://example.com/storage/api/admin`, the console
+`https://example.com/storage/admin` (its `<base href>` is rewritten to match),
+and the health/metrics endpoints follow too.
+
+```bash
+docker run -d --name openbucket \
+  -e MOUNT_PATH=/storage \
+  -e DATA_DIR=/data \
+  --env-file .env \
+  -v openbucket-data:/data \
+  ghcr.io/projectbay/openbucket:latest
+```
+
+Forward the prefix **as-is** — do not strip it, because SigV4 signs the full
+request path and the store verifies over the same path:
+
+```nginx
+location /storage/ {
+  proxy_set_header Host              $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_request_buffering off;
+  client_max_body_size    0;
+  proxy_pass http://127.0.0.1:9000;   # note: no trailing slash — keeps /storage/… intact
+}
+```
+
+Point your S3 client's `endpoint` at `https://example.com/storage` with path-style
+addressing, and probe health at `https://example.com/storage/api/admin/health`.
+
+:::tip[MOUNT_PATH is the authoritative prefix]
+The prefix comes from `MOUNT_PATH`, not from a forwarded header — so a
+misconfigured proxy can't relocate the admin API out from under its guard. Leave
+`MOUNT_PATH` unset to keep everything at the root, exactly as before. It is the
+standalone twin of `OpenBucketModule.forRoot({ mountPath })`.
+:::
+
 ## A minimal Kubernetes sketch
 
 OpenBucket is single-node (one writer over SQLite + a local blob tree), so run it

--- a/apps/docs/docs/operations/monitoring.md
+++ b/apps/docs/docs/operations/monitoring.md
@@ -64,7 +64,7 @@ object key, or client IP):
 | `openbucket_integrity_last_run_timestamp` | gauge | — |
 | `openbucket_process_*` / `openbucket_nodejs_*` | default | — |
 
-:::note What updates when
+:::note[What updates when]
 HTTP counters and the latency histogram are recorded live by the request
 interceptor. The per-bucket gauges are refreshed on the **usage-rollup** tick
 (`USAGE_ROLLUP_INTERVAL_MS`, default 15 min) from an in-memory aggregate — so a

--- a/apps/docs/docs/operations/upgrading.md
+++ b/apps/docs/docs/operations/upgrading.md
@@ -40,7 +40,7 @@ Two independently-versioned artifacts ship from the one codebase:
 - **The embeddable library** — `@openbucket/nestjs` on npm, currently on
   pre-release versions.
 
-:::tip Pin exact versions in production
+:::tip[Pin exact versions in production]
 Deploy a pinned tag (`ghcr.io/<owner>/openbucket:0.1.0` or an exact npm version),
 not `:latest`/`next`. Pinning makes an upgrade a deliberate, reviewable change and
 keeps two environments reproducibly identical.
@@ -59,7 +59,7 @@ to snapshot before upgrading: **rolling back means restoring the pre-upgrade
 snapshot**, not reversing a migration. Applied migrations are logged
 (`Applied N migration(s) on init`).
 
-:::warning Don't downgrade the image against an upgraded database
+:::warning[Don't downgrade the image against an upgraded database]
 Once a newer version has migrated `openbucket.db` forward, an **older** image may
 not understand the new schema. If you need to go back, restore the snapshot you
 took before the upgrade rather than pointing an old binary at a new database.

--- a/apps/docs/docs/reference/admin-api.md
+++ b/apps/docs/docs/reference/admin-api.md
@@ -38,7 +38,7 @@ Access tokens are short-lived (default 900 s); refresh tokens live in the
 `ob_refresh` cookie (default 7 days). Send the access token as
 `Authorization: Bearer <token>` on every non-public call.
 
-:::info Typed client & OpenAPI
+:::info[Typed client & OpenAPI]
 The backend exports an OpenAPI document, and [`@openbucket/api-client`](https://github.com/ProjectBay/openbucket/tree/main/libs/api-client)
 is generated from it (openapi-generator, `typescript-angular`) — one typed service
 per endpoint group. The admin console consumes it directly. Regenerate with
@@ -73,7 +73,7 @@ per endpoint group. The admin console consumes it directly. Regenerate with
 - **Rate limiting.** The admin plane is throttled (login is 5/min). A `429`
   carries `Retry-After`; clients should not hammer-retry.
 
-:::note Errors
+:::note[Errors]
 Errors use a JSON envelope (`{ error, message, statusCode }`) with S3-style HTTP
 codes — `401` (unauthenticated), `403` (read-only or forbidden), `404`,
 `409` (e.g. `BucketNotEmpty`), `429` (rate limited).

--- a/apps/docs/docs/reference/cli-reference.md
+++ b/apps/docs/docs/reference/cli-reference.md
@@ -20,7 +20,7 @@ The password is read from `$OPENBUCKET_PASSWORD` or an interactive non-echoing
 prompt — **never** a flag. Set `$OPENBUCKET_TOKEN` to reuse a bearer token and
 skip login entirely.
 
-:::note Default endpoint
+:::note[Default endpoint]
 `--endpoint` defaults to `http://127.0.0.1:3900` (the dev-serve port). For a
 standalone Docker instance, pass `--endpoint http://127.0.0.1:9000` or set
 `$OPENBUCKET_ENDPOINT`.
@@ -69,7 +69,7 @@ openbucket buckets ls --json
 openbucket keys create --label tenant-42 --scope prefix:uploads/tenant-42/
 ```
 
-:::warning The secret is shown once
+:::warning[The secret is shown once]
 `keys create` prints `secretAccessKey` exactly once — capture it immediately.
 Under `--json` the whole created-key DTO is emitted so it can be captured
 machine-readably.
@@ -87,7 +87,7 @@ openbucket backup create -o nightly.zip
 openbucket backup restore -f nightly.zip --yes
 ```
 
-:::warning Restore resets the target
+:::warning[Restore resets the target]
 `backup restore` resets the instance (or the named bucket) before restoring. It
 issues **no request at all** — not even a login — unless you pass `--yes`.
 :::

--- a/apps/docs/docs/reference/configuration.md
+++ b/apps/docs/docs/reference/configuration.md
@@ -54,10 +54,21 @@ anything required is missing or malformed. Unknown variables are ignored.
 | --- | --- | --- |
 | `NODE_ENV` | `production` | One of `development` / `test` / `production`. |
 | `PORT` | `9000` | HTTP listen port. |
+| `MOUNT_PATH` | — (root) | Route prefix everything mounts under — S3 (`<MOUNT_PATH>/<bucket>/<key>`), admin API (`<MOUNT_PATH>/api/admin`), admin console (`<MOUNT_PATH>/admin`), health & metrics. Empty = root. Set it to run behind a reverse proxy at a subpath (e.g. `/storage`). Normalized to a leading slash, no trailing slash. |
 | `LOG_LEVEL` | `info` | `trace` / `debug` / `info` / `warn` / `error` / `fatal`. |
 | `ADMIN_USERNAME` | `admin` | Bootstrap admin login. |
 | `JWT_ACCESS_TTL_SECONDS` | `900` | Access-token lifetime (60–3600). |
 | `JWT_REFRESH_TTL_SECONDS` | `604800` | Refresh-token lifetime (3600–2592000, i.e. 1 h–30 d). |
+
+:::tip[Running at a subpath]
+`MOUNT_PATH` moves the **whole** OpenBucket surface under one prefix so it can sit
+behind a reverse proxy at, say, `https://example.com/storage/…` without a
+dedicated subdomain. The admin SPA's `<base href>` is rewritten to match, and
+the admin API stays guarded at `<MOUNT_PATH>/api/admin/*`. Point your S3 client's
+endpoint at `https://example.com/storage` (path-style). It is the standalone twin
+of the embedded module's `OpenBucketModule.forRoot({ mountPath })`. See
+[Deployment → behind a reverse proxy](../operations/deployment.md#running-behind-a-reverse-proxy-at-a-subpath).
+:::
 
 ### S3 protocol
 

--- a/apps/docs/docs/reference/configuration.md
+++ b/apps/docs/docs/reference/configuration.md
@@ -25,7 +25,7 @@ ROOT_SECRET_ACCESS_KEY=$(openssl rand -base64 48)
 Everything else has a sensible default. The full, commented template lives in
 [`.env.example`](https://github.com/ProjectBay/openbucket/blob/main/.env.example).
 
-:::tip Generate strong secrets
+:::tip[Generate strong secrets]
 `JWT_SECRET`, `ROOT_SECRET_ACCESS_KEY`, `KEY_ENCRYPTION_SECRET`, `WEBHOOK_SECRET`,
 and a `token`-mode `METRICS_TOKEN` are all validated as **strong secrets**: at
 least 32 characters, at least 8 distinct characters, not a single repeated
@@ -304,14 +304,14 @@ Omit to disable. Exactly one of `cron` / `intervalMinutes` must be set.
 | `metrics.token` | — | Strong bearer token — required when `mode: 'token'`. |
 | `tracing.enabled` | `false` | OpenTelemetry span wrapping. No-op unless `@opentelemetry/api` + an SDK are present. |
 
-:::info Static options in `forRootAsync`
+:::info[Static options in `forRootAsync`]
 `mountPath`, `serveUi`, and `admin` (the on/off switch) are **static** — passed
 alongside `useFactory` because routing is wired at module-config time. The admin
 *secrets* still come from the async factory. See the
 [NestJS module reference](./nestjs-module.md#async-configuration).
 :::
 
-:::warning Refuse-to-boot validation
+:::warning[Refuse-to-boot validation]
 Both entry points validate security-critical formats before serving a single
 request: a non-argon2id `passwordHash`, a too-short `jwtSecret`, a weak
 `rootCredentials.secretAccessKey`, a `token`-mode metrics endpoint behind a weak

--- a/apps/docs/docs/reference/nestjs-module.md
+++ b/apps/docs/docs/reference/nestjs-module.md
@@ -10,7 +10,7 @@ embed an **S3-compatible object store** (wire protocol, admin JSON API, and admi
 console SPA) directly inside your own NestJS application, configured in code. For a
 quick orientation, start with [Embedding in NestJS](../getting-started/quickstart-embed.md).
 
-:::tip Deep-dive references
+:::tip[Deep-dive references]
 This page covers wiring the module. For the details, see the focused guides:
 [Configuration](./configuration.md) (every option + env var),
 [OpenBucketService API](./openbucket-service.md) (the injectable facade),
@@ -153,7 +153,7 @@ The facade covers: `putObject`, `getObjectStream`, `getObjectBuffer`, `headObjec
 domain errors (`NoSuchBucketError`, `NoSuchKeyError`, …) — catch them or pre-check
 with `bucketExists` / `headObject`.
 
-:::tip Presigned URLs
+:::tip[Presigned URLs]
 Presigned URLs are signed for the public origin you pass as `baseUrl` (scheme +
 host); the configured `mountPath` and the object path are appended for you, so the
 URL verifies against the mounted S3 routes. `baseUrl` defaults to the `endpoint`
@@ -288,7 +288,7 @@ const files = await this.db.file.findMany({ where: { ownerId } });
 return files.map((f) => this.toDto(f)); // each gets a fresh 1-hour URL
 ```
 
-:::tip Storing a plain URL column
+:::tip[Storing a plain URL column]
 Either store `presignGetUrl(...)` with a longer `expiresIn` (max **7 days**) and
 re-mint it periodically, or — for a bucket you deliberately make public (an
 anonymous-GET bucket policy) — store the stable path-style URL

--- a/apps/docs/docs/reference/openbucket-service.md
+++ b/apps/docs/docs/reference/openbucket-service.md
@@ -97,7 +97,7 @@ Key options on `UploadOptions`: `key` (explicit, wins over `keyStrategy`),
 `keyStrategy` (default `'uuid'`), `validate`, `contentType`, `filename`, `image`,
 and `presign` (a `PresignOptions` object, or `false` to skip URL minting).
 
-:::warning Active content is rejected by default
+:::warning[Active content is rejected by default]
 `uploadFrom` rejects HTML/XHTML/SVG bodies unless you opt in — defense in depth
 for the stored-XSS surface. On a rejected upload it throws `UploadValidationError`
 (map its `statusHint` of `400` to a `BadRequestException`).
@@ -138,7 +138,7 @@ const { url, fields } = this.ob.createPresignedPost('avatars', {
 `maxObjectSizeMb` cap when you omit one, so a minted token can never authorise an
 object larger than the server allows.
 
-:::note `baseUrl` is required unless `endpoint` is set
+:::note[`baseUrl` is required unless `endpoint` is set]
 Presign throws if neither a `baseUrl` nor the `endpoint` option resolves an
 origin. Pass `baseUrl: 'https://files.example.com'` (scheme + host only).
 :::

--- a/apps/docs/docs/reference/s3-compatibility.md
+++ b/apps/docs/docs/reference/s3-compatibility.md
@@ -114,7 +114,7 @@ against the real `aws` CLI, MinIO's `mc`, and `s3cmd`.
 
 ## Known limitations
 
-:::warning Path-style addressing only
+:::warning[Path-style addressing only]
 Virtual-host-style addressing (`bucket.host/key`) is **not** supported. Always set
 `forcePathStyle: true` in your SDK — requests go to `host/bucket/key`.
 :::
@@ -132,7 +132,7 @@ Virtual-host-style addressing (`bucket.host/key`) is **not** supported. Always s
 - **Region.** OpenBucket reports a single configured region (default `us-east-1`);
   it does not emulate cross-region behaviour or redirects.
 
-:::tip Compatibility beyond the AWS SDK
+:::tip[Compatibility beyond the AWS SDK]
 The conformance suite runs the same object round-trips through the `aws` CLI,
 MinIO's `mc`, and `s3cmd`, so those tools work against OpenBucket out of the box —
 point them at the endpoint with path-style addressing and the root credentials.

--- a/apps/openbucket-backend-e2e/src/mount-path.e2e-spec.ts
+++ b/apps/openbucket-backend-e2e/src/mount-path.e2e-spec.ts
@@ -1,0 +1,158 @@
+import { createHash } from 'node:crypto';
+import { request } from 'node:http';
+import * as aws4 from 'aws4';
+
+import { SpawnedApp, spawnApp } from './support/spawn-app';
+
+/**
+ * MOUNT_PATH — the standalone server running under a subpath (behind a reverse
+ * proxy at e.g. `https://example.com/storage/…`). Proves that with
+ * `MOUNT_PATH=/storage` every surface moves under the prefix and stays correct:
+ *
+ * - the admin API is guarded at `<mountPath>/api/admin/*` (unauth → 401),
+ * - the public health probe answers at `<mountPath>/api/admin/health`,
+ * - path-style S3 (bucket + object PUT/GET) verifies SigV4 and resolves under
+ *   the prefix (the client signs the full `/storage/...` path; the server
+ *   verifies over the same path and the classifier strips `/storage` to route),
+ * - nothing is left mounted at the bare root.
+ *
+ * A companion block asserts the UNSET default is byte-for-byte the old root
+ * behaviour (no regression).
+ */
+const CREDS = {
+  accessKeyId: 'AKIA1234567890ABCD',
+  secretAccessKey: 'e2eRootSecretAccessKey9f3a7c1e5b2d08X6Yk',
+};
+
+interface Res {
+  status: number;
+  headers: Record<string, string | string[] | undefined>;
+  body: string;
+}
+
+/** Signed S3 request against `host` at the given (already mount-prefixed) `path`. */
+function signed(
+  host: string,
+  port: number,
+  method: string,
+  path: string,
+  body?: string,
+): Promise<Res> {
+  const opts: aws4.Request = {
+    host,
+    method,
+    path,
+    service: 's3',
+    region: 'us-east-1',
+    headers: {},
+    body,
+  };
+  aws4.sign(opts, CREDS);
+  const headers = opts.headers as Record<string, string>;
+  return new Promise((resolve, reject) => {
+    const req = request({ hostname: '127.0.0.1', port, method, path, headers }, (res) => {
+      let buf = '';
+      res.on('data', (c) => (buf += c));
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers, body: buf }));
+    });
+    req.on('error', reject);
+    if (body !== undefined) req.write(body);
+    req.end();
+  });
+}
+
+describe('MOUNT_PATH=/storage (e2e)', () => {
+  const PORT = 9242;
+  const HOST = `127.0.0.1:${PORT}`;
+  let app: SpawnedApp;
+  const bucket = 'mount-bucket';
+
+  beforeAll(async () => {
+    app = await spawnApp(PORT, { MOUNT_PATH: '/storage' });
+  }, 40_000);
+
+  afterAll(async () => {
+    app?.kill('SIGKILL');
+    await app?.waitForExit();
+  });
+
+  it('health probe answers under the mount', async () => {
+    const res = await fetch(`${app.baseUrl}/storage/api/admin/health`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe('ok');
+  });
+
+  it('guards the admin API under the mount — unauthenticated → 401', async () => {
+    const res = await fetch(`${app.baseUrl}/storage/api/admin/buckets`);
+    expect(res.status).toBe(401);
+  });
+
+  it('leaves nothing mounted at the bare root — /api/admin/health → 404', async () => {
+    const res = await fetch(`${app.baseUrl}/api/admin/health`);
+    expect(res.status).toBe(404);
+  });
+
+  it('serves path-style S3 under the mount: PUT bucket + object, GET object', async () => {
+    const created = await signed(HOST, PORT, 'PUT', `/storage/${bucket}`);
+    expect(created.status).toBe(200);
+
+    const payload = 'hello under a mount';
+    const md5 = createHash('md5').update(payload).digest('hex');
+    const put = await signed(HOST, PORT, 'PUT', `/storage/${bucket}/greeting.txt`, payload);
+    expect(put.status).toBe(200);
+    // MD5 ETag proves the object landed through the full signed write path.
+    expect(String(put.headers['etag'])).toContain(md5);
+
+    const got = await signed(HOST, PORT, 'GET', `/storage/${bucket}/greeting.txt`);
+    expect(got.status).toBe(200);
+    expect(got.body).toBe(payload);
+  });
+
+  it('does not serve S3 at the bare root under a mount (root PUT → not the store)', async () => {
+    // The S3 tree is only mapped under `/storage`; a signed request to the root
+    // bucket path matches no controller there → 404 (never a 2xx that would mean
+    // the store answered off-prefix).
+    const res = await signed(HOST, PORT, 'PUT', `/root-bucket`);
+    expect(res.status).toBe(404);
+  });
+
+  it('does not 5xx the (unbundled) SPA path under the mount', async () => {
+    // No dist/spa in the e2e build, so the shell isn't served — but the path must
+    // resolve to a clean client status, never a crash. (Base-href rewrite under a
+    // mount is covered by the library unit test.)
+    const res = await fetch(`${app.baseUrl}/storage/admin/`);
+    expect(res.status).toBeLessThan(500);
+  });
+});
+
+describe('MOUNT_PATH unset — root behaviour unchanged (e2e)', () => {
+  const PORT = 9243;
+  let app: SpawnedApp;
+
+  beforeAll(async () => {
+    app = await spawnApp(PORT);
+  }, 40_000);
+
+  afterAll(async () => {
+    app?.kill('SIGKILL');
+    await app?.waitForExit();
+  });
+
+  it('health answers at the root', async () => {
+    const res = await fetch(`${app.baseUrl}/api/admin/health`);
+    expect(res.status).toBe(200);
+  });
+
+  it('admin API guarded at the root — unauthenticated → 401', async () => {
+    const res = await fetch(`${app.baseUrl}/api/admin/buckets`);
+    expect(res.status).toBe(401);
+  });
+
+  it('a `/storage/...` path is just an ordinary S3 bucket named "storage" (no prefix magic)', async () => {
+    const res = await fetch(`${app.baseUrl}/storage/some/key`);
+    // Unsigned → SigV4 rejects as S3 XML; the bucket is literally "storage".
+    expect(res.headers.get('content-type')).toContain('application/xml');
+    const xml = await res.text();
+    expect(xml).toContain('<Resource>/storage/some/key</Resource>');
+  });
+});

--- a/apps/openbucket-backend/src/main.ts
+++ b/apps/openbucket-backend/src/main.ts
@@ -9,14 +9,43 @@ import { getMikroORMToken } from '@mikro-orm/nestjs';
 import { Logger } from 'nestjs-pino';
 import express, { type Express } from 'express';
 import helmet from 'helmet';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { AppConfigService, OpenBucketCoreModule, OPEN_BUCKET_ORM_CONTEXT } from '@openbucket/nestjs';
+import {
+  AppConfigService,
+  OpenBucketCoreModule,
+  OpenBucketStandaloneModule,
+  OPEN_BUCKET_ORM_CONTEXT,
+  normalizeMount,
+  rewriteBaseHref,
+} from '@openbucket/nestjs';
 import { configureBodyParsers } from './bootstrap/body-parser';
 
 async function bootstrap(): Promise<void> {
   const expressInstance: Express = express();
+
+  // Optional subpath the whole server mounts under (S3 + admin API + admin SPA +
+  // health/metrics), for running behind a reverse proxy at e.g.
+  // `https://example.com/storage/…`. Read straight from process.env here because
+  // it must be known BEFORE the module graph is built (RouterModule wires the
+  // prefix at module-config time, before ConfigService exists). Normalized with
+  // the SAME helper the env schema uses, so both agree. Empty ⇒ root (unchanged).
+  const mountPath = normalizeMount(process.env.MOUNT_PATH ?? '');
+  // NOTE (trusted-proxy `X-Forwarded-Prefix`): MOUNT_PATH is intentionally the
+  // single, authoritative prefix. Route registration is wired ONCE at boot
+  // (RouterModule) and the admin JWT guard's prefix is derived from it, so a
+  // per-request forwarded header could not relocate the guarded routes and would
+  // be a footgun (a spoofed prefix must never move the admin API out from under
+  // its guard). If forwarded-prefix awareness is ever needed, gate it strictly on
+  // Express `trust proxy` AND keep MOUNT_PATH authoritative for routing — do not
+  // let the header override it. Left as a deliberate non-feature for now.
+  // Root: boot the core module directly (the pre-existing path, unchanged). Under
+  // a mount: the standalone wrapper prefixes every route via RouterModule and
+  // provides the mount-aware OPEN_BUCKET_OPTIONS token. See OpenBucketStandaloneModule.
+  const rootModule = mountPath
+    ? OpenBucketStandaloneModule.forRoot(mountPath)
+    : OpenBucketCoreModule;
 
   // Disable Express's defaults. Body parsing is opt-in per route (§1.2.3).
   expressInstance.disable('x-powered-by');
@@ -34,7 +63,9 @@ async function bootstrap(): Promise<void> {
   const app = await NestFactory.create<NestExpressApplication>(
     // The standalone app always serves the admin surface — the env schema (§1.7)
     // requires JWT_SECRET + ADMIN_PASSWORD_HASH, so admin is never headless here.
-    OpenBucketCoreModule,
+    // At root this is OpenBucketCoreModule; under a MOUNT_PATH it is the wrapper
+    // that prefixes the whole tree (see above).
+    rootModule,
     new ExpressAdapter(expressInstance),
     {
       bufferLogs: true, // hold logs until Pino is bound
@@ -104,14 +135,24 @@ async function bootstrap(): Promise<void> {
         res.setHeader('Cache-Control', 'public, max-age=300');
       }
     };
+    // Mount the SPA under `<mountPath>/admin` (root ⇒ `/admin`, unchanged). Hashed
+    // assets are served straight from disk; `index: false` routes the shell
+    // through the handler below so its `<base href>` is rewritten to
+    // `<mountPath>/admin/` — the SAME rewrite the embedded SpaController applies,
+    // reused here (a no-op at root, where the build-time href is already
+    // `/admin/`). The shell is read + rewritten once at boot (the bundle is
+    // immutable). Registered BEFORE app.listen() maps the greedy S3 `:bucket`
+    // routes, so `<mountPath>/admin/*` wins over an S3 bucket named "admin".
+    const adminBase = `${mountPath}/admin`;
+    const shellHtml = rewriteBaseHref(readFileSync(indexHtml, 'utf8'), mountPath);
     expressInstance.use(
-      '/admin',
-      express.static(spaRoot, { index: 'index.html', setHeaders: cacheHeaders }),
+      adminBase,
+      express.static(spaRoot, { index: false, setHeaders: cacheHeaders }),
     );
-    // SPA client-side routing: any unmatched /admin/* path falls back to the shell.
-    expressInstance.get('/admin/{*splat}', (_req, res) => {
+    // The mount root + any unmatched client-side route under it → the SPA shell.
+    expressInstance.get([adminBase, `${adminBase}/{*splat}`], (_req, res) => {
       res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-      res.sendFile(indexHtml);
+      res.type('html').send(shellHtml);
     });
   }
 

--- a/libs/nestjs/src/index.ts
+++ b/libs/nestjs/src/index.ts
@@ -44,6 +44,15 @@ export { OpenBucketCoreModule } from './lib/open-bucket-core.module';
 export { AdminModule } from './lib/admin/admin.module';
 export { HealthModule } from './lib/admin/health/health.module';
 
+// Standalone `MOUNT_PATH` support: the wrapper root module that mounts the whole
+// tree under a subpath, plus the two pure helpers `main.ts` needs to be
+// mount-aware without duplicating logic — `normalizeMount` (the same
+// normalization the env schema + `forRoot` apply) and `rewriteBaseHref` (the SPA
+// `<base href>` rewrite the embedded SpaController uses).
+export { OpenBucketStandaloneModule } from './lib/open-bucket-standalone.module';
+export { normalizeMount } from './lib/open-bucket-options';
+export { rewriteBaseHref } from './lib/spa/spa-utils';
+
 // Config service consumed by the standalone app's main.ts (phase 0b).
 export { AppConfigService } from './lib/common/config/app-config.service';
 

--- a/libs/nestjs/src/lib/common/config/app-config.service.ts
+++ b/libs/nestjs/src/lib/common/config/app-config.service.ts
@@ -14,6 +14,14 @@ export class AppConfigService {
   get nodeEnv(): Env['NODE_ENV'] { return this.raw.get('NODE_ENV', { infer: true }); }
   get port(): number { return this.raw.get('PORT', { infer: true }); }
   get logLevel(): Env['LOG_LEVEL'] { return this.raw.get('LOG_LEVEL', { infer: true }); }
+  /**
+   * Route prefix everything mounts under (normalized: leading slash, no trailing
+   * slash; `''` = root). Standalone reads `MOUNT_PATH`; the embedded module maps
+   * `forRoot({ mountPath })` here via config-source. Mount-aware consumers read
+   * the resolved value from the `OPEN_BUCKET_OPTIONS` token, which the standalone
+   * `MOUNT_PATH` boot path provides — this getter is the config-layer twin.
+   */
+  get mountPath(): string { return this.raw.get('MOUNT_PATH', { infer: true }); }
   get dataDir(): string { return this.raw.get('DATA_DIR', { infer: true }); }
   get jwtSecret(): string { return this.raw.get('JWT_SECRET', { infer: true }); }
   get jwtAccessTtl(): number { return this.raw.get('JWT_ACCESS_TTL_SECONDS', { infer: true }); }

--- a/libs/nestjs/src/lib/common/config/config-source.ts
+++ b/libs/nestjs/src/lib/common/config/config-source.ts
@@ -15,7 +15,13 @@ import { type Env, loadEnv } from './env.schema';
  * the env schema only make sense for raw string env input.
  */
 export function buildConfig(opts?: ResolvedOpenBucketOptions): Env {
-  if (!opts) return loadEnv(process.env);
+  // Standalone marker: no options, OR a mount-only options object (the standalone
+  // MOUNT_PATH boot provides `OPEN_BUCKET_OPTIONS` carrying just `mountPath` so
+  // the mount-aware consumers read the prefix from the same token as the library
+  // — that object deliberately omits `rootCredentials`). Either way, source the
+  // whole config from `process.env` as before; the mapping below is only for a
+  // real `forRoot(options)` host, which always resolves `rootCredentials`.
+  if (!opts || !opts.rootCredentials) return loadEnv(process.env);
   return {
     // App-level (the host owns its process/listener/logger; sensible defaults).
     NODE_ENV: (process.env.NODE_ENV as Env['NODE_ENV']) || 'production',
@@ -23,6 +29,11 @@ export function buildConfig(opts?: ResolvedOpenBucketOptions): Env {
     LOG_LEVEL: 'info',
     SHUTDOWN_DRAIN_MS: 30_000,
 
+    // Route prefix everything mounts under. The library carries it on the
+    // OPEN_BUCKET_OPTIONS token (mount-aware consumers read it there); mapping it
+    // into the env-shaped config keeps `AppConfigService.mountPath` consistent in
+    // both modes.
+    MOUNT_PATH: opts.mountPath,
     DATA_DIR: opts.dataDir,
     JWT_SECRET: opts.admin?.jwtSecret ?? '',
     JWT_ACCESS_TTL_SECONDS: opts.admin?.jwtAccessTtl ?? 900,

--- a/libs/nestjs/src/lib/common/config/env.schema.ts
+++ b/libs/nestjs/src/lib/common/config/env.schema.ts
@@ -114,6 +114,22 @@ export const validateCronExpression = (cron: string): string | null => {
   }
 };
 
+/**
+ * Normalize a route mount prefix: leading slash, no trailing slash; `''` (root)
+ * allowed. Shared by the library (`OpenBucketModule.forRoot({ mountPath })`) and
+ * the standalone `MOUNT_PATH` env var so both accept the same spellings
+ * (`storage`, `/storage`, `/storage/` → `/storage`; `''` / `/` → `''`). Lives
+ * here (config layer) so `env.schema` can reuse it without importing back up into
+ * `open-bucket-options` (which already imports from this module); the public
+ * re-export in `open-bucket-options` preserves the existing import site.
+ */
+export function normalizeMount(p: string): string {
+  let m = p.trim();
+  if (m === '/' || m === '') return '';
+  if (!m.startsWith('/')) m = `/${m}`;
+  return m.replace(/\/+$/, '');
+}
+
 export const validateReplicationEndpoint = (
   endpoint: string,
 ): { error?: string; insecure?: boolean } => {
@@ -135,6 +151,17 @@ export const EnvSchema = z
     NODE_ENV: z.enum(['development', 'test', 'production']).default('production'),
     PORT: portNumber.default(9000),
     LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).default('info'),
+
+    // --- routing ---
+    // Route prefix the STANDALONE server mounts EVERYTHING under — the S3 wire
+    // protocol (`<MOUNT_PATH>/<bucket>/<key>`), the admin JSON API
+    // (`<MOUNT_PATH>/api/admin/*`), the admin SPA (`<MOUNT_PATH>/admin`), and
+    // health/metrics. Empty (the default) keeps everything at the root, exactly
+    // as before. Set it to run behind a reverse proxy that exposes OpenBucket at a
+    // subpath (e.g. `https://example.com/storage/…`). Normalized to a leading
+    // slash with no trailing slash (`storage`/`/storage/` → `/storage`); mirrors
+    // the embedded module's `OpenBucketModule.forRoot({ mountPath })`.
+    MOUNT_PATH: z.string().default('').transform(normalizeMount),
 
     // --- persistence ---
     DATA_DIR: z

--- a/libs/nestjs/src/lib/open-bucket-options.ts
+++ b/libs/nestjs/src/lib/open-bucket-options.ts
@@ -2,12 +2,18 @@ import type { ModuleMetadata, Type } from '@nestjs/common';
 import { z } from 'zod';
 
 import {
+  normalizeMount,
   S3_BUCKET_RE,
   strongSecret,
   validateCronExpression,
   validateReplicationEndpoint,
   validateWebhookUrl,
 } from './common/config/env.schema';
+
+// Re-exported for the existing import sites (open-bucket.module.ts, tests) that
+// pull `normalizeMount` from here. It now lives in `env.schema` so the standalone
+// `MOUNT_PATH` env var can share it without a config → options import cycle.
+export { normalizeMount };
 
 /**
  * Configuration for {@link OpenBucketModule}. Replaces the standalone app's
@@ -451,12 +457,4 @@ export function validateSecurityCriticalOptions(o: ResolvedOpenBucketOptions): v
       .join('\n');
     throw new Error(`OpenBucketModule: invalid configuration (fix before boot):\n${issues}`);
   }
-}
-
-/** Leading slash, no trailing slash; `''` (root) allowed. */
-export function normalizeMount(p: string): string {
-  let m = p.trim();
-  if (m === '/' || m === '') return '';
-  if (!m.startsWith('/')) m = `/${m}`;
-  return m.replace(/\/+$/, '');
 }

--- a/libs/nestjs/src/lib/open-bucket-standalone.module.spec.ts
+++ b/libs/nestjs/src/lib/open-bucket-standalone.module.spec.ts
@@ -1,0 +1,120 @@
+import { type INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import request from 'supertest';
+
+import { normalizeMount } from './common/config/env.schema';
+import { buildConfig } from './common/config/config-source';
+import { OPEN_BUCKET_OPTIONS, type ResolvedOpenBucketOptions } from './open-bucket-options';
+import { OpenBucketStandaloneModule } from './open-bucket-standalone.module';
+
+/**
+ * Standalone `MOUNT_PATH` support. `OpenBucketStandaloneModule.forRoot('/storage')`
+ * mounts the whole tree under the prefix by reusing the library's RouterModule
+ * machinery and provides a mount-only `OPEN_BUCKET_OPTIONS` token, so the
+ * admin-guard, classifier, and S3/SigV4 flow all become mount-aware WITHOUT any
+ * per-consumer wiring. Boots the real core graph (env-driven, like the standalone
+ * app) and drives it over HTTP.
+ */
+describe('normalizeMount (MOUNT_PATH normalization)', () => {
+  it.each([
+    ['', ''],
+    ['/', ''],
+    ['storage', '/storage'],
+    ['/storage', '/storage'],
+    ['/storage/', '/storage'],
+    ['  /storage  ', '/storage'],
+    ['/a/b/', '/a/b'],
+  ])('normalizes %p → %p', (input, expected) => {
+    expect(normalizeMount(input)).toBe(expected);
+  });
+});
+
+describe('buildConfig dual-mode marker (mount-only options → env)', () => {
+  it('treats a mount-only OPEN_BUCKET_OPTIONS (no rootCredentials) as standalone/env', () => {
+    const saved = { ...process.env };
+    Object.assign(process.env, {
+      NODE_ENV: 'test',
+      DATA_DIR: '/d',
+      MOUNT_PATH: '/storage',
+      JWT_SECRET: 'k7Jf2pQrwStN9vB3zX1cM4dL0eR6yU2h7gK3nP5s',
+      ROOT_ACCESS_KEY_ID: 'AKIA0000000000000000',
+      ROOT_SECRET_ACCESS_KEY: 'k7Jf2pQrwStN9vB3zX1cM4dL0eR6yU2h7gK3nP5s',
+      ADMIN_PASSWORD_HASH: '$argon2id$v=19$m=65536,t=3,p=4$abc$def',
+    });
+    try {
+      // The mount-only marker must NOT be mapped as library config — it lacks
+      // rootCredentials, so config comes from process.env (which carries MOUNT_PATH).
+      const cfg = buildConfig({ mountPath: '/storage' } as ResolvedOpenBucketOptions);
+      expect(cfg.DATA_DIR).toBe('/d');
+      expect(cfg.MOUNT_PATH).toBe('/storage');
+    } finally {
+      process.env = saved;
+    }
+  });
+});
+
+describe('OpenBucketStandaloneModule.forRoot — server under a MOUNT_PATH', () => {
+  let app: INestApplication;
+  let dataDir: string;
+  const savedEnv = { ...process.env };
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), 'ob-mount-'));
+    Object.assign(process.env, {
+      NODE_ENV: 'test',
+      DATA_DIR: dataDir,
+      MOUNT_PATH: '/storage',
+      JWT_SECRET: 'k7Jf2pQrwStN9vB3zX1cM4dL0eR6yU2h7gK3nP5s',
+      ROOT_ACCESS_KEY_ID: 'AKIA1234567890ABCD',
+      ROOT_SECRET_ACCESS_KEY: 'k7Jf2pQrwStN9vB3zX1cM4dL0eR6yU2h7gK3nP5s',
+      ADMIN_PASSWORD_HASH: '$argon2id$v=19$m=65536,t=3,p=4$abc$def',
+    });
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [OpenBucketStandaloneModule.forRoot('/storage')],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+    process.env = savedEnv;
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('provides a mount-aware OPEN_BUCKET_OPTIONS token', () => {
+    const opts = app.get<ResolvedOpenBucketOptions>(OPEN_BUCKET_OPTIONS);
+    expect(opts.mountPath).toBe('/storage');
+  });
+
+  it('serves the public health probe under the mount', async () => {
+    const res = await request(app.getHttpServer()).get('/storage/api/admin/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ status: 'ok' });
+  });
+
+  it('guards the admin API under the mount — unauthenticated → 401', async () => {
+    const res = await request(app.getHttpServer()).get('/storage/api/admin/buckets');
+    expect(res.status).toBe(401);
+  });
+
+  it('does not mount the admin API at the ROOT (no prefix) — 404', async () => {
+    // The route only exists under `/storage`; a root hit matches no controller.
+    const res = await request(app.getHttpServer()).get('/api/admin/buckets');
+    expect(res.status).toBe(404);
+  });
+
+  it('classifies a path-style request under the mount as S3 (XML error, not admin/404)', async () => {
+    // Unsigned S3 request under the prefix → SigV4 rejects with the S3 XML shape,
+    // and the classifier stripped `/storage` so the bucket is `some-bucket` (NOT
+    // `storage`): the Resource is `/some-bucket/key.txt`, proving mount-aware S3.
+    const res = await request(app.getHttpServer()).get('/storage/some-bucket/key.txt');
+    expect(res.headers['content-type']).toContain('application/xml');
+    expect(res.text).toContain('<Resource>/some-bucket/key.txt</Resource>');
+  });
+});

--- a/libs/nestjs/src/lib/open-bucket-standalone.module.ts
+++ b/libs/nestjs/src/lib/open-bucket-standalone.module.ts
@@ -1,0 +1,84 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { RouterModule } from '@nestjs/core';
+
+import { ADMIN_CONTROLLER_MODULES } from './admin/admin.module';
+import { HealthModule } from './admin/health/health.module';
+import { MetricsModule } from './common/metrics/metrics.module';
+import { OpenBucketCoreModule } from './open-bucket-core.module';
+import {
+  normalizeMount,
+  OPEN_BUCKET_OPTIONS,
+  type ResolvedOpenBucketOptions,
+} from './open-bucket-options';
+import { S3Module } from './s3/s3.module';
+
+/**
+ * Root module for the STANDALONE server (`apps/openbucket-backend`) when it runs
+ * under a `MOUNT_PATH` subpath. It reuses the SAME mount machinery the embedded
+ * `OpenBucketModule.forRoot` uses — a `RouterModule` prefix over the exact set of
+ * controller-declaring modules — so no route wiring is duplicated:
+ *
+ * - `RouterModule.register` prefixes each listed child module's OWN controllers
+ *   with `<mountPath>` (the admin JSON API, health, `/metrics`, and the greedy
+ *   S3 `:bucket` tree last). Those modules are imported transitively by
+ *   {@link OpenBucketCoreModule}; they are listed as children here purely to move
+ *   their routes under the prefix. The admin SPA is served from the raw Express
+ *   instance in `main.ts` (mount-aware, with the `<base href>` rewritten via the
+ *   library's `rewriteBaseHref`), so `SpaModule` is intentionally NOT a child.
+ *
+ * - The mount-only `OPEN_BUCKET_OPTIONS` provider makes every mount-aware
+ *   consumer (`RequestClassifierMiddleware`, `JwtAuthGuard`, `RolesGuard`, the
+ *   `AuthController` refresh-cookie scope, the S3 presign base path, …) read
+ *   `<mountPath>` from the same DI token the library populates — so the admin API
+ *   stays guarded at `<mountPath>/api/admin/*` and S3 classifies correctly under
+ *   the prefix, with zero per-consumer changes. It carries ONLY `mountPath` (no
+ *   `rootCredentials`), which is the standalone marker the dual-mode
+ *   `ConfigModule` uses to keep sourcing the rest of config from `process.env`
+ *   (see `config-source.ts`). The provider is `global` so it reaches the deep
+ *   consumers inside the core-module subtree (mirrors `forRoot`).
+ *
+ * When `MOUNT_PATH` is unset/root, `main.ts` boots {@link OpenBucketCoreModule}
+ * directly instead — this wrapper is only used for a non-empty prefix, so the
+ * root deployment is byte-for-byte unchanged.
+ */
+@Module({})
+export class OpenBucketStandaloneModule {
+  /**
+   * @param rawMountPath the raw `MOUNT_PATH` value (normalized here). Callers pass
+   * a non-empty prefix; an empty/root value returns a plain wrapper around the
+   * core module with no prefixing (defensive — `main.ts` handles root directly).
+   */
+  static forRoot(rawMountPath: string): DynamicModule {
+    const mountPath = normalizeMount(rawMountPath);
+    if (!mountPath) {
+      return { module: OpenBucketStandaloneModule, imports: [OpenBucketCoreModule] };
+    }
+
+    const optionsProvider = {
+      provide: OPEN_BUCKET_OPTIONS,
+      // Mount-only marker (no rootCredentials → config still sourced from env).
+      useValue: { mountPath } as ResolvedOpenBucketOptions,
+    };
+
+    return {
+      module: OpenBucketStandaloneModule,
+      global: true,
+      imports: [
+        OpenBucketCoreModule,
+        RouterModule.register([
+          {
+            path: mountPath,
+            module: OpenBucketCoreModule,
+            // Every module that DECLARES controllers, so RouterModule prefixes
+            // them. S3Module (greedy `:bucket`) stays last, matching the core
+            // module's own import order. SpaModule is omitted — the SPA is served
+            // by Express in main.ts.
+            children: [...ADMIN_CONTROLLER_MODULES, HealthModule, MetricsModule, S3Module],
+          },
+        ]),
+      ],
+      providers: [optionsProvider],
+      exports: [optionsProvider],
+    };
+  }
+}


### PR DESCRIPTION
Two things you flagged.

## 1. `MOUNT_PATH` for the standalone Docker image
The standalone image booted at root with no way to serve under a subpath (`mountPath` was an embed-only `forRoot` option). Now:
- `MOUNT_PATH` env var → a new `OpenBucketStandaloneModule.forRoot(mountPath)` mounts the whole controller tree under the prefix via `RouterModule` (reusing the library's mount machinery). Unset = **root, byte-for-byte unchanged**.
- The value threads through the existing `OPEN_BUCKET_OPTIONS.mountPath`, so the **JwtAuthGuard admin-prefix**, request classifier, **SigV4/S3 routing**, **presigned URLs**, and the **SPA base-href** all become mount-aware with **zero per-consumer changes**.
- `X-Forwarded-Prefix` is **deliberately not trusted** — a per-request header must never relocate the guarded admin API; `MOUNT_PATH` is the single authoritative prefix.
- New e2e (9 tests) proves `MOUNT_PATH=/storage` serves S3 + admin + guard under `/storage`, and default-root is unchanged. Docs added to configuration + deployment.

## 2. Docs admonitions rendered as literal text
Docusaurus 3.10 dropped the `:::type Title` space syntax; **82 admonitions** across the docs were showing as `:::warning …` text. Converted all to the `:::type[Title]` bracket syntax — they now render as proper callouts (verified: 0 literal `:::` in the built HTML).

## Validation
nestjs build+lint clean · **1164 unit** · backend e2e **37 suites** (mount-path 9/9) · webpack bundle builds · docs build clean. No version bump in the PR.

After merge I'll cut **alpha.15 on both channels** (npm `nestjs-v*` **and** Docker `v*`) to also sync the stale GHCR image.