### PR TITLE
security: remediate CodeQL alerts + single-tag dual release

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+name: OpenBucket CodeQL config
+
+# Scope the JS/TS analysis to hand-written, shipped source.
+#
+# paths-ignore removes findings that are either not maintainable by us or never
+# reach a production runtime:
+#   - libs/api-client/**  — openapi-generator output (`nx run api-client:generate`),
+#     regenerated wholesale from the exported OpenAPI doc. Never hand-edited, so
+#     its js/unused-local-variable "note" alerts are noise (47 of them).
+#   - **/admin/_test/**   — TestController and its module are mounted ONLY when
+#     OPENBUCKET_TEST_MODE=1 (see open-bucket-core.module.ts) and are never present
+#     in a production/standalone container, so the js/resource-exhaustion finding on
+#     the deliberately test-only /slow endpoint (already clamped to 60s) is inert.
+paths-ignore:
+  - libs/api-client/**
+  - '**/admin/_test/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default for every job (actions/missing-workflow-permissions):
+# read-only. The one job that needs more (build-image → GHCR) widens its own
+# scope with a job-level `permissions:` block that overrides this default.
+permissions:
+  contents: read
+
 env:
   # Node 22 matches the Docker base and satisfies Angular's require(ESM)
   # (22.x >=22.12). The SQLite driver (libsql) ships N-API prebuilds that are
@@ -54,7 +60,7 @@ jobs:
         run: npm audit --omit=dev --audit-level=high
 
       - name: Derive nx affected base
-        uses: nrwl/nx-set-shas@v5
+        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       - name: Lint
         run: npx nx run-many --target=lint --all --parallel=4
@@ -100,7 +106,7 @@ jobs:
       image-tag: ${{ steps.meta.outputs.tag }}
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - id: meta
         name: Compute image tag
@@ -114,7 +120,7 @@ jobs:
           fi
 
       - name: Build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           language: ${{ matrix.language }}
           queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/release-nestjs.yml
+++ b/.github/workflows/release-nestjs.yml
@@ -20,7 +20,10 @@ name: release-nestjs
 
 on:
   push:
-    tags: ['nestjs-v*']
+    # A plain `v*` tag ships BOTH the npm package (this workflow) and the Docker
+    # image (release-docker.yml) from one tag. `nestjs-v*` is kept for npm-only
+    # releases. The version-verify step below strips either prefix.
+    tags: ['v*', 'nestjs-v*']
   workflow_dispatch:
 
 concurrency:
@@ -60,6 +63,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           tag_version="${GITHUB_REF_NAME#nestjs-v}"
+          tag_version="${tag_version#v}"
           pkg_version="$(node -p "require('./libs/nestjs/package.json').version")"
           if [ "$tag_version" != "$pkg_version" ]; then
             echo "::error::Tag $GITHUB_REF_NAME ($tag_version) != libs/nestjs/package.json version $pkg_version"

--- a/libs/nestjs/src/lib/common/config/env.schema.spec.ts
+++ b/libs/nestjs/src/lib/common/config/env.schema.spec.ts
@@ -2,7 +2,7 @@ import { ConfigModule } from '@nestjs/config';
 import { Test } from '@nestjs/testing';
 
 import { AppConfigService } from './app-config.service';
-import { loadEnv } from './env.schema';
+import { loadEnv, normalizeMount } from './env.schema';
 
 /**
  * TEST-0012 — env schema validation + refuse-to-boot semantics.
@@ -486,5 +486,31 @@ describe('loadEnv scheduled backups (STORY-1203)', () => {
       }),
     ).toThrow('Refusing to boot: invalid environment.');
     expect(errSpy.mock.calls[0][0]).toContain('OB_SCHEDULED_BACKUP_CRON is not a valid cron');
+  });
+});
+
+describe('normalizeMount (ReDoS-free trailing-slash trim)', () => {
+  it.each([
+    ['', ''],
+    ['/', ''],
+    ['//', ''],
+    ['storage', '/storage'],
+    ['/storage', '/storage'],
+    ['/storage/', '/storage'],
+    ['storage///', '/storage'],
+    ['  /storage/  ', '/storage'],
+    ['/a/b/c/', '/a/b/c'],
+  ])('normalizeMount(%j) -> %j', (input, expected) => {
+    expect(normalizeMount(input)).toBe(expected);
+  });
+
+  it('is linear on a long trailing-slash run (no polynomial backtracking)', () => {
+    // A pathological input for the old `/\/+$/`: many slashes NOT terminating the
+    // string. Must return promptly and correctly with the linear scan.
+    const evil = '/x' + '/'.repeat(200_000) + 'y';
+    const start = Date.now();
+    // No trailing slash to strip (ends in 'y') → returned unchanged.
+    expect(normalizeMount(evil)).toBe(evil);
+    expect(Date.now() - start).toBeLessThan(1000);
   });
 });

--- a/libs/nestjs/src/lib/common/config/env.schema.ts
+++ b/libs/nestjs/src/lib/common/config/env.schema.ts
@@ -127,7 +127,12 @@ export function normalizeMount(p: string): string {
   let m = p.trim();
   if (m === '/' || m === '') return '';
   if (!m.startsWith('/')) m = `/${m}`;
-  return m.replace(/\/+$/, '');
+  // Strip trailing '/' with a linear scan rather than a regex: `/\/+$/` is an
+  // unanchored one-or-more quantifier that backtracks O(n²) on a long run of
+  // slashes that doesn't reach the end (js/polynomial-redos). Same result.
+  let end = m.length;
+  while (end > 0 && m.charCodeAt(end - 1) === 0x2f /* '/' */) end--;
+  return m.slice(0, end);
 }
 
 export const validateReplicationEndpoint = (

--- a/libs/nestjs/src/lib/s3/sigv4/presigned.ts
+++ b/libs/nestjs/src/lib/s3/sigv4/presigned.ts
@@ -15,6 +15,15 @@ import { Sigv4Verifier } from './sigv4.verifier';
 export const MAX_EXPIRES = 7 * 24 * 60 * 60; // AWS: max 7 days.
 const MAX_SKEW_MS = 15 * 60 * 1000;
 
+/** Strip leading and trailing '/' in a single linear pass (ReDoS-free). */
+function trimSlashes(s: string): string {
+  let start = 0;
+  let end = s.length;
+  while (start < end && s.charCodeAt(start) === 0x2f) start++;
+  while (end > start && s.charCodeAt(end - 1) === 0x2f) end--;
+  return s.slice(start, end);
+}
+
 /**
  * Verify a presigned-URL request (WHITEPAPER §2.5). Differs from header-based
  * SigV4 in three ways: the signature is the `X-Amz-Signature` query param
@@ -146,9 +155,10 @@ export function buildPresignedUrl(p: PresignInput): string {
     .map((s) => awsUriEncode(s, false))
     .join('/');
   // Normalise the mount prefix: leading slash, no trailing slash, `''` for root.
-  const prefix = p.basePath
-    ? `/${p.basePath.replace(/^\/+/, '').replace(/\/+$/, '')}`.replace(/^\/$/, '')
-    : '';
+  // trimSlashes is a linear scan — `/\/+$/` is an unanchored one-or-more
+  // quantifier that backtracks O(n²) on a long slash run (js/polynomial-redos).
+  const trimmed = trimSlashes(p.basePath ?? '');
+  const prefix = trimmed ? `/${trimmed}` : '';
   const pathname = `${prefix}/${awsUriEncode(p.bucket, false)}/${encodedKey}`;
 
   const params = new URLSearchParams();

--- a/libs/nestjs/src/lib/s3/sigv4/sigv4.guard.ts
+++ b/libs/nestjs/src/lib/s3/sigv4/sigv4.guard.ts
@@ -150,10 +150,15 @@ export class SigV4Guard implements CanActivate {
     //                          SignedHeaders=host;x-amz-content-sha256;x-amz-date,
     //                          Signature=hex…
     const body = authz.slice('AWS4-HMAC-SHA256 '.length);
-    const parts: Record<string, string> = {};
+    // Null-prototype map keyed by an allowlist of the only three directives we
+    // consume. Both guards defuse js/remote-property-injection: the header name
+    // `k` is attacker-controlled, so restricting writes to known keys (and using
+    // a prototype-less object) prevents it from reaching `__proto__`/prototype.
+    const ALLOWED_DIRECTIVES = new Set(['Credential', 'SignedHeaders', 'Signature']);
+    const parts: Record<string, string> = Object.create(null);
     for (const seg of body.split(',')) {
       const [k, v] = seg.trim().split('=');
-      if (k && v) parts[k] = v;
+      if (k && v && ALLOWED_DIRECTIVES.has(k)) parts[k] = v;
     }
     const cred = parts['Credential'];
     if (!cred) throw new AccessDeniedError('missing Credential');

--- a/libs/nestjs/src/lib/s3/sigv4/sigv4.spec.ts
+++ b/libs/nestjs/src/lib/s3/sigv4/sigv4.spec.ts
@@ -241,6 +241,29 @@ describe('SigV4 (TEST-0104)', () => {
     expect(parsed.signature).toBe('deadbeef');
   });
 
+  it('case 10b: parseAuthorization ignores unknown/__proto__ directives (js/remote-property-injection)', () => {
+    const guard = mkGuard(ROOT_CREDS) as unknown as {
+      parseAuthorization(a: string): {
+        accessKeyId: string;
+        signedHeaders: string[];
+        signature: string;
+      };
+    };
+    const before = Object.prototype as unknown as Record<string, unknown>;
+    const parsed = guard.parseAuthorization(
+      'AWS4-HMAC-SHA256 __proto__=polluted, constructor=x, ' +
+        'Credential=AKID/20260520/us-east-1/s3/aws4_request, ' +
+        'SignedHeaders=host, Signature=deadbeef',
+    );
+    // Real directives still parse; the injected ones are dropped, not stored.
+    expect(parsed.accessKeyId).toBe('AKID');
+    expect(parsed.signature).toBe('deadbeef');
+    expect(parsed.signedHeaders).toEqual(['host']);
+    // Object.prototype is untouched.
+    expect(before['polluted']).toBeUndefined();
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+  });
+
   it('happy path: a valid aws4-signed header request authenticates and stamps accessKeyId', async () => {
     const { req } = signedReq({ host: 'my-bucket.localhost', path: '/some/key.txt' });
     const guard = mkGuard(ROOT_CREDS);

--- a/libs/nestjs/src/lib/storage/key-codec.spec.ts
+++ b/libs/nestjs/src/lib/storage/key-codec.spec.ts
@@ -77,6 +77,13 @@ describe('encodeKey / decodeKey', () => {
       const segment = 'a'.repeat(255);
       expect(encodeKey(segment)).toBe(segment);
     });
+
+    it('rejects a raw segment of 256 bytes at the pre-loop bound (js/loop-bound-injection)', () => {
+      // 256 unreserved bytes would encode 1:1 to 256 bytes (> 255). The new
+      // pre-loop cap rejects it before the encode loop runs — same accept/reject
+      // outcome as the post-encode check it complements.
+      expect(() => encodeKey('a'.repeat(256))).toThrow(KeyTooLongError);
+    });
   });
 
   describe('roundtrip', () => {

--- a/libs/nestjs/src/lib/storage/key-codec.ts
+++ b/libs/nestjs/src/lib/storage/key-codec.ts
@@ -34,6 +34,15 @@ const UNRESERVED = new Set<number>();
 
 const HEX = '0123456789ABCDEF';
 
+/**
+ * Per-segment byte cap. The encoded output can only grow (each byte maps to 1
+ * or 3 output chars), so a raw segment longer than this can never encode to
+ * <= 255 bytes and is rejected up front — this both preserves the existing
+ * length semantics and gives the encode loop a provably-constant upper bound
+ * (CWE-834, js/loop-bound-injection).
+ */
+const MAX_SEGMENT_BYTES = 255;
+
 // Placeholder for an EMPTY key segment (from a trailing slash — an S3 "folder
 // marker" like `photos/` — or a `//` in the key). Left as '' it would produce a
 // path ending in (or containing a doubled) '/', which can't be a filename
@@ -49,6 +58,13 @@ function encodeByte(b: number): string {
 function encodeSegment(segment: string): string {
   if (segment.length === 0) return EMPTY_SEGMENT; // trailing/double slash → safe placeholder
   const bytes = Buffer.from(segment, 'utf8');
+  // Bound the loop before entering it (js/loop-bound-injection): the encoded
+  // form is never shorter than the raw bytes, so anything past this cap would
+  // fail the post-encode 255-byte check anyway — reject it here so the loop
+  // bound is a constant.
+  if (bytes.length > MAX_SEGMENT_BYTES) {
+    throw new KeyTooLongError(segment);
+  }
   let out = '';
   for (let i = 0; i < bytes.length; i++) {
     const b = bytes[i];
@@ -74,7 +90,7 @@ function encodeSegment(segment: string): string {
     out = out.slice(0, -1) + '%20';
   }
 
-  if (Buffer.byteLength(out, 'utf8') > 255) {
+  if (Buffer.byteLength(out, 'utf8') > MAX_SEGMENT_BYTES) {
     throw new KeyTooLongError(segment);
   }
   return out;

--- a/libs/nestjs/src/lib/storage/paths.spec.ts
+++ b/libs/nestjs/src/lib/storage/paths.spec.ts
@@ -1,0 +1,58 @@
+import { resolve, sep } from 'node:path';
+
+import { PathEscapeError, PathResolver } from './paths';
+
+/**
+ * Containment-barrier coverage for the CWE-22 defense-in-depth guard added to
+ * PathResolver. Two properties:
+ *   1. Every real (codec-encoded or well-formed) input resolves to a path
+ *      contained within DATA_DIR — the barrier is a no-op that never changes
+ *      the layout.
+ *   2. A crafted traversal segment that reaches a resolver un-encoded (bucket
+ *      name, uploadId) is rejected with PathEscapeError instead of escaping.
+ */
+describe('PathResolver containment barrier', () => {
+  const DATA = '/data';
+  const paths = new PathResolver(DATA);
+  const blobs = resolve(DATA, 'blobs');
+  const multipart = resolve(DATA, 'multipart');
+
+  const within = (p: string, base: string) => p === base || p.startsWith(base + sep);
+
+  describe('contained for well-formed input', () => {
+    it('blobPath stays under blobs/', () => {
+      const p = paths.blobPath('mybucket', 'a/b/c.txt');
+      expect(within(p, blobs)).toBe(true);
+    });
+
+    it('a key full of ".." is codec-encoded, so it stays contained (no throw)', () => {
+      const p = paths.blobPath('mybucket', '../../../etc/passwd');
+      expect(within(p, blobs)).toBe(true);
+      // ".." never survives as a literal traversal segment.
+      expect(p).not.toContain(`${sep}..${sep}`);
+    });
+
+    it('versionPath / multipartPartPath stay under their bases', () => {
+      expect(within(paths.versionPath('b', 'k', 'v1'), blobs)).toBe(true);
+      expect(within(paths.multipartPartPath('upload-1', 3), multipart)).toBe(true);
+    });
+  });
+
+  describe('rejects un-encoded traversal at the barrier', () => {
+    it('a traversal bucket name throws PathEscapeError', () => {
+      expect(() => paths.bucketDir('../../etc')).toThrow(PathEscapeError);
+      expect(() => paths.blobPath('../../etc', 'k')).toThrow(PathEscapeError);
+    });
+
+    it('a traversal uploadId throws PathEscapeError', () => {
+      expect(() => paths.multipartDir('../../../etc')).toThrow(PathEscapeError);
+      expect(() => paths.multipartPartPath('../../../etc', 1)).toThrow(PathEscapeError);
+    });
+
+    it('an absolute-escape bucket throws PathEscapeError', () => {
+      // join() would let a leading-slash-heavy name resolve elsewhere; the
+      // barrier catches anything that lands outside blobs/.
+      expect(() => paths.bucketDir('../../../../../../tmp')).toThrow(PathEscapeError);
+    });
+  });
+});

--- a/libs/nestjs/src/lib/storage/paths.ts
+++ b/libs/nestjs/src/lib/storage/paths.ts
@@ -1,6 +1,46 @@
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 
 import { encodeKey } from './key-codec';
+
+/**
+ * Thrown when a resolved on-disk path would escape its intended base directory
+ * (CWE-22, path traversal). In practice unreachable: the key-codec
+ * ({@link encodeKey}) percent-encodes `.`, `/` and control bytes so no `..`
+ * traversal sequence can survive into a path segment. It exists so a future
+ * regression in the codec — or a caller that reaches the filesystem without
+ * going through it — fails closed with a clear error instead of silently
+ * escaping DATA_DIR.
+ */
+export class PathEscapeError extends Error {
+  override readonly name = 'PathEscapeError';
+  constructor(readonly base: string, readonly target: string) {
+    super(`resolved path escapes its base directory: ${target} not within ${base}`);
+  }
+}
+
+/**
+ * Defense-in-depth containment barrier (CWE-22). Normalises `target` with
+ * `path.resolve` — collapsing any `.`/`..` segments — and asserts the result
+ * stays within `base`, returning the resolved (and thus provably-contained)
+ * path that all filesystem callers then use.
+ *
+ * Every path that folds in a user-influenced segment (S3 key, bucket name,
+ * multipart uploadId) is funnelled through here at this single choke-point
+ * before it can reach the fs layer, so a traversal sequence that somehow
+ * bypassed the key-codec is rejected here rather than escaping DATA_DIR.
+ *
+ * This is a NO-OP for every real input: `base` is derived from an absolute
+ * DATA_DIR and the variable segments are codec-encoded (no `.`/`/`), so
+ * `resolve` is idempotent and the on-disk layout is unchanged.
+ */
+function contain(base: string, target: string): string {
+  const resolvedBase = resolve(base);
+  const resolved = resolve(target);
+  if (resolved !== resolvedBase && !resolved.startsWith(resolvedBase + sep)) {
+    throw new PathEscapeError(resolvedBase, resolved);
+  }
+  return resolved;
+}
 
 export class PathResolver {
   constructor(private readonly dataDir: string) {}
@@ -9,26 +49,29 @@ export class PathResolver {
     return join(this.dataDir, 'blobs');
   }
   bucketDir(bucket: string): string {
-    return join(this.blobsDir(), bucket);
+    return contain(this.blobsDir(), join(this.blobsDir(), bucket));
   }
   blobPath(bucket: string, key: string): string {
-    return join(this.bucketDir(bucket), encodeKey(key));
+    return contain(this.blobsDir(), join(this.bucketDir(bucket), encodeKey(key)));
   }
   versionDir(bucket: string, key: string): string {
-    return this.blobPath(bucket, key) + '.v';
+    return contain(this.blobsDir(), this.blobPath(bucket, key) + '.v');
   }
   versionPath(bucket: string, key: string, versionId: string): string {
-    return join(this.versionDir(bucket, key), versionId);
+    return contain(this.blobsDir(), join(this.versionDir(bucket, key), versionId));
   }
   multipartDir(uploadId: string): string {
-    return join(this.dataDir, 'multipart', uploadId);
+    return contain(this.multipartRoot(), join(this.multipartRoot(), uploadId));
   }
   /** Root of the multipart staging tree (parent of each upload's dir). */
   multipartRoot(): string {
     return join(this.dataDir, 'multipart');
   }
   multipartPartPath(uploadId: string, partNumber: number): string {
-    return join(this.multipartDir(uploadId), `${partNumber}.part`);
+    return contain(
+      this.multipartRoot(),
+      join(this.multipartDir(uploadId), `${partNumber}.part`),
+    );
   }
   tmpDir(): string {
     return join(this.dataDir, 'tmp');

--- a/libs/ui/spartan-formly/src/lib/validators/validators.spec.ts
+++ b/libs/ui/spartan-formly/src/lib/validators/validators.spec.ts
@@ -1,0 +1,47 @@
+import { AbstractControl } from '@angular/forms';
+
+import { urlValidatorExpression } from './validators';
+
+/** Minimal control stub — the validators only read `.value`. */
+const ctrl = (value: unknown) => ({ value }) as AbstractControl;
+
+/**
+ * The URL validator's path segment was rewritten from the nested `([/\w .-]*)*`
+ * (catastrophic backtracking, js/redos) to a flat `[/\w .-]*` class. These cases
+ * pin the accept/reject semantics and prove the linear runtime.
+ */
+describe('urlValidatorExpression', () => {
+  it('accepts empty (delegates to required)', () => {
+    expect(urlValidatorExpression(ctrl(''))).toBe(true);
+    expect(urlValidatorExpression(ctrl(null))).toBe(true);
+  });
+
+  it.each([
+    'example.com',
+    'http://example.com',
+    'https://example.com',
+    'https://sub.example.com/path/to/thing',
+    'https://example.co.uk/a-b_c.d/',
+    'www.example.com/path with spaces',
+  ])('accepts %j', (v) => {
+    expect(urlValidatorExpression(ctrl(v))).toBe(true);
+  });
+
+  it.each([
+    'nodot',
+    'https://例え.テスト', // non-ASCII host (unchanged behaviour: rejected)
+    'ht!tp://x.com',
+  ])('rejects %j', (v) => {
+    expect(urlValidatorExpression(ctrl(v))).toBe(false);
+  });
+
+  it('runs in linear time on a ReDoS attack string', () => {
+    // The classic catastrophic input for `([/\w .-]*)*`: a long run of matching
+    // path chars followed by a non-matching terminator that forces the anchored
+    // `$` to fail. The flat class returns promptly.
+    const evil = 'http://example.com/' + '/'.repeat(50_000) + '!';
+    const start = Date.now();
+    expect(urlValidatorExpression(ctrl(evil))).toBe(false);
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+});

--- a/libs/ui/spartan-formly/src/lib/validators/validators.ts
+++ b/libs/ui/spartan-formly/src/lib/validators/validators.ts
@@ -28,9 +28,15 @@ export function emailValidatorExpression(control: AbstractControl): boolean {
 // ============================================================================
 
 /**
- * URL regex pattern
+ * URL regex pattern.
+ *
+ * The path portion is a single `[/\w .-]*` class rather than the nested
+ * `([/\w .-]*)*` it replaces: the inner group could match empty, making the
+ * outer `*` ambiguous and catastrophically backtrack (js/redos). A flat
+ * character class accepts exactly the same strings without the nested
+ * quantifier.
  */
-const URL_REGEX = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})([/\w .-]*)*\/?$/;
+const URL_REGEX = /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})[/\w .-]*\/?$/;
 
 /**
  * URL validator expression


### PR DESCRIPTION
Fixes the two follow-ups — and corrects a mistake: the failing **CodeQL** check was flagging **real alerts**, not a config conflict. All are now addressed.

## CodeQL remediation
| Rule | Count | Fix |
|---|---|---|
| `js/path-injection` | 22 | Containment barrier at the path choke-point (`paths.ts` `contain()`: `path.resolve` + base-prefix assert → `PathEscapeError`). No-op for codec-encoded keys; **real defense-in-depth** for bucket names / uploadIds. |
| `js/polynomial-redos` / `redos` | 3 | Linear replacements (`normalizeMount`, presigned `trimSlashes`, formly `URL_REGEX`) — accept/reject parity verified. |
| `js/loop-bound-injection` | 1 | Cap segment length before the encode loop. |
| `js/remote-property-injection` | 1 | Null-proto object + directive allowlist in the SigV4 guard. |
| `js/resource-exhaustion` | 1 | `_test` controller is test-only (`OPENBUCKET_TEST_MODE`); excluded from scanning. |
| `actions/*` | 6 | Least-privilege `permissions:` + SHA-pinned actions in `ci.yml`. |
| `js/unused-local-variable` | 47 | Generated `api-client` excluded via `.github/codeql/codeql-config.yml`. |

## Dual release
`release-nestjs.yml` now also triggers on a plain `v*` tag (strips either `nestjs-v`/`v` prefix), so **one `v*` tag ships both** the npm package and the Docker image.

## Validation
nestjs build+lint clean · **1182 unit** · formly 11 · webpack build · backend e2e **175** — all green. Behavior-preserving (the path barrier is a no-op in practice; SigV4 semantics unchanged).

I'll confirm the **CodeQL check actually passes** on this PR before merging.