### PR TITLE
fix(admin-ui): group object-browser pagination controls into one row

### DIFF
--- a/apps/openbucket-frontend/src/app/objects/object-browser.component.ts
+++ b/apps/openbucket-frontend/src/app/objects/object-browser.component.ts
@@ -224,58 +224,59 @@ import { fileIcon } from './object-icon';
           }
         </div>
 
-        <nav hlmPagination>
-          <ul hlmPaginationContent>
-            <li hlmPaginationItem>
-              <button
-                hlmBtn
-                variant="ghost"
-                size="sm"
-                class="gap-1 pl-2.5"
-                [disabled]="stack.length <= 1"
-                (click)="back()"
-              >
-                <ng-icon
-                  name="lucideChevronLeft"
-                  class="text-base"
-                />
-                <span class="hidden sm:block">{{ 'objects.previous' | translate }}</span>
-              </button>
-            </li>
-            <li hlmPaginationItem>
-              <button
-                hlmBtn
-                variant="ghost"
-                size="sm"
-                class="gap-1 pr-2.5"
-                [disabled]="!nextMarker()"
-                (click)="nextPage()"
-              >
-                <span class="hidden sm:block">{{ 'objects.next' | translate }}</span>
-                <ng-icon
-                  name="lucideChevronRight"
-                  class="text-base"
-                />
-              </button>
-            </li>
-          </ul>
-        </nav>
+        <div class="flex items-center gap-2">
+          <nav hlmPagination>
+            <ul hlmPaginationContent>
+              <li hlmPaginationItem>
+                <button
+                  hlmBtn
+                  variant="ghost"
+                  size="sm"
+                  class="gap-1 pl-2.5"
+                  [disabled]="stack.length <= 1"
+                  (click)="back()"
+                >
+                  <ng-icon
+                    name="lucideChevronLeft"
+                    class="text-base"
+                  />
+                  <span class="hidden sm:block">{{ 'objects.previous' | translate }}</span>
+                </button>
+              </li>
+              <li hlmPaginationItem>
+                <button
+                  hlmBtn
+                  variant="ghost"
+                  size="sm"
+                  class="gap-1 pr-2.5"
+                  [disabled]="!nextMarker()"
+                  (click)="nextPage()"
+                >
+                  <span class="hidden sm:block">{{ 'objects.next' | translate }}</span>
+                  <ng-icon
+                    name="lucideChevronRight"
+                    class="text-base"
+                  />
+                </button>
+              </li>
+            </ul>
+          </nav>
 
-        <brn-select
-          hlm
-          class="ml-auto"
-          [ngModel]="pageSize()"
-          (ngModelChange)="onPageSize($event)"
-        >
-          <hlm-select-trigger class="w-fit">
-            <hlm-select-value />
-          </hlm-select-trigger>
-          <hlm-select-content>
-            @for (n of pageSizes; track n) {
-              <hlm-option [value]="n">{{ n }} {{ 'objects.perPage' | translate }}</hlm-option>
-            }
-          </hlm-select-content>
-        </brn-select>
+          <brn-select
+            hlm
+            [ngModel]="pageSize()"
+            (ngModelChange)="onPageSize($event)"
+          >
+            <hlm-select-trigger class="w-fit">
+              <hlm-select-value />
+            </hlm-select-trigger>
+            <hlm-select-content>
+              @for (n of pageSizes; track n) {
+                <hlm-option [value]="n">{{ n }} {{ 'objects.perPage' | translate }}</hlm-option>
+              }
+            </hlm-select-content>
+          </brn-select>
+        </div>
       </div>
 
       @if (error()) {


### PR DESCRIPTION
The bucket **object browser** footer rendered the item count, the Prev/Next pager, and the items-per-page select as three flex siblings under `justify-between`. At constrained widths (e.g. inside the bucket-detail tab) `flex-wrap` broke each onto its own row — three stacked rows.

**Fix:** wrap the Prev/Next `nav` and the per-page `brn-select` in a single right-aligned group. Now the footer is **count on the left · controls on the right**, and when width is tight the controls wrap together as one unit (a clean 2-row layout) instead of stacking into three.

Frontend-only, behavior unchanged. `nx build`/`lint openbucket-frontend` green. Ships with the next library/image release (the admin SPA is bundled into `@openbucket/nestjs`).