### PR TITLE
security(docs): patch serialize-javascript RCE/DoS in the docs site

### DIFF
--- a/apps/docs/package-lock.json
+++ b/apps/docs/package-lock.json
@@ -16411,15 +16411,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17405,12 +17396,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -27,6 +27,9 @@
     "@docusaurus/module-type-aliases": "3.10.1",
     "@docusaurus/types": "3.10.1"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
+  },
   "browserslist": {
     "production": [
       ">0.5%",


### PR DESCRIPTION
## What

Clears the two highest-severity open Dependabot alerts by forcing the patched
`serialize-javascript` in the docs site:

- **#104 (high)** — RCE via `RegExp.flags` / `Date.prototype.toISOString()`
- **#106 (medium)** — CPU-exhaustion DoS

`apps/docs` (Docusaurus) had `serialize-javascript` **6.0.2**, pulled transitively
by `copy-webpack-plugin` and `css-minimizer-webpack-plugin`. An npm `override` to
`^7.0.5` resolves it to **7.0.7**.

## Risk / why this is safe

`serialize-javascript` here is **build-time only** — `apps/docs` is a static-site
generator (deployed to GitHub Pages) whose deps never ship in `@openbucket/nestjs`
or the Docker image, and a static build has no attacker-controlled input to
`serialize()`. So the practical risk was low; this just keeps the security tab clean.

The 6→7 major bump was verified: **`npm run build` (docusaurus) succeeds** with
7.0.7 — the css/copy webpack minifier plugins run cleanly (only a pre-existing,
unrelated HTML-minifier content warning remains).

## Not addressed here (triage notes)

The other 6 open alerts are all **dev/build-tooling or the docs generator**, none in
the shipped runtime tree, and force-bumping them risks breaking the build:

- `uuid` (#105, apps/docs) — v4 usage, advisory is about v3/v5/v6-with-buffer → not
  exploitable; 8→11 would risk the Docusaurus build.
- `ajv` (#7), `http-proxy-middleware` (#77/#96), `esbuild` (#51), `picomatch` (#15)
  — all `dev`, from Angular devkit / spartan-ng CLI / ng-packagr. Blanket bumps
  collide with peers (e.g. eslint's ajv 6). Candidates for scoped overrides or a
  documented Dependabot dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
