### PR TITLE
feat(docs): cookieless first-party docs-site analytics (no 3rd party)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -37,6 +37,11 @@ jobs:
           cache-dependency-path: apps/docs/package-lock.json
       - run: npm ci
       - run: npm run build
+        # Activates the cookieless first-party pageview beacon (apps/docs-analytics).
+        # No-op until the DOCS_ANALYTICS_URL repository variable is set to the
+        # collector's /collect endpoint (Settings → Secrets and variables → Actions).
+        env:
+          DOCS_ANALYTICS_URL: ${{ vars.DOCS_ANALYTICS_URL }}
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/apps/docs-analytics/.dockerignore
+++ b/apps/docs-analytics/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+*.db
+*.db-shm
+*.db-wal
+.env
+.git

--- a/apps/docs-analytics/.env.example
+++ b/apps/docs-analytics/.env.example
@@ -1,0 +1,27 @@
+# OpenBucket docs-analytics collector — configuration.
+# Copy to `.env` and set the values, or pass them as environment variables.
+
+# HTTP listen port.
+PORT=8787
+
+# Path to the SQLite database file (persist this on a volume in production).
+DB_PATH=./analytics.db
+
+# The docs-site origin allowed to POST pageviews. Use a concrete origin in
+# production to reject casual cross-site spam; "*" accepts any origin.
+ALLOWED_ORIGIN=https://projectbay.github.io
+
+# Bearer token required to view /stats and /stats.json. REQUIRED to expose stats.
+# Generate one, e.g.:  node -e "console.log(require('crypto').randomBytes(24).toString('base64url'))"
+STATS_TOKEN=
+
+# Raw event rows older than this are pruned nightly (uniques/rollups beyond this
+# window are not retained). Default 365 days.
+RETENTION_DAYS=365
+
+# Trust X-Forwarded-For for the client IP (set true when behind a reverse proxy
+# such as nginx/Caddy terminating TLS; the IP is only hashed, never stored raw).
+TRUST_PROXY=true
+
+# Max accepted beacon body size in bytes (defense against oversized posts).
+MAX_BODY_BYTES=2048

--- a/apps/docs-analytics/.gitignore
+++ b/apps/docs-analytics/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+*.db
+*.db-shm
+*.db-wal
+.env

--- a/apps/docs-analytics/Dockerfile
+++ b/apps/docs-analytics/Dockerfile
@@ -1,0 +1,26 @@
+# Multi-stage build for the docs-analytics collector.
+# Stage 1: install + compile TypeScript. Stage 2: slim runtime image.
+
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build && npm prune --omit=dev
+
+FROM node:22-slim
+WORKDIR /app
+ENV NODE_ENV=production \
+    DB_PATH=/data/analytics.db \
+    PORT=8787
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./
+RUN mkdir -p /data && chown -R node:node /data
+VOLUME ["/data"]
+EXPOSE 8787
+USER node
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||8787)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+CMD ["node", "dist/server.js"]

--- a/apps/docs-analytics/README.md
+++ b/apps/docs-analytics/README.md
@@ -1,0 +1,84 @@
+# openbucket-docs-analytics
+
+A tiny **cookieless, first-party** pageview collector for the OpenBucket
+documentation site — **no third-party services**. The docs site (Docusaurus on
+GitHub Pages) sends an anonymous beacon on each page view to a collector **you**
+run on your own VPS; it stores aggregate counts in SQLite and serves a small
+stats dashboard.
+
+- **No cookies, no `localStorage`, no fingerprinting, no PII at rest.** The client
+  IP + User-Agent are combined with a **per-day rotating salt** and SHA-256 hashed
+  into a visitor id used only for daily de-duplication. The raw IP is never stored,
+  and the daily salt rotation means visitors can't be correlated across days.
+- Respects `navigator.doNotTrack`.
+- Footprint: one small Node process + a SQLite file. No Postgres, no ClickHouse.
+
+## Endpoints
+
+| Method | Path          | Purpose                                              |
+| ------ | ------------- | ---------------------------------------------------- |
+| `POST` | `/collect`    | Ingest a beacon (called by the docs site).           |
+| `GET`  | `/stats`      | HTML dashboard (bearer token).                       |
+| `GET`  | `/stats.json` | Same data as JSON (bearer token).                    |
+| `GET`  | `/health`     | Liveness probe → `ok`.                               |
+
+`/stats` accepts the token as `Authorization: Bearer <token>` **or** `?token=<token>`
+(handy for viewing in a browser).
+
+## Configuration
+
+See [`.env.example`](./.env.example). The essentials:
+
+| Variable         | Default                        | Notes                                             |
+| ---------------- | ------------------------------ | ------------------------------------------------- |
+| `PORT`           | `8787`                         | HTTP listen port.                                 |
+| `DB_PATH`        | `./analytics.db`               | SQLite file (persist on a volume).                |
+| `ALLOWED_ORIGIN` | `*`                            | Docs origin allowed to POST; set to lock it down. |
+| `STATS_TOKEN`    | —                              | **Required** to view `/stats`. Generate a random one. |
+| `RETENTION_DAYS` | `365`                          | Raw events older than this are pruned nightly.    |
+| `TRUST_PROXY`    | `true`                         | Use `X-Forwarded-For` (behind nginx/Caddy).       |
+
+## Run it (on your VPS)
+
+```bash
+# 1. A token to protect the stats page:
+export STATS_TOKEN=$(node -e "console.log(require('crypto').randomBytes(24).toString('base64url'))")
+
+# 2. Start it (binds to 127.0.0.1:8787):
+docker compose up --build -d
+```
+
+Put it behind your existing TLS reverse proxy, e.g. nginx:
+
+```nginx
+location / {
+    proxy_pass http://127.0.0.1:8787;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+```
+
+Then it's reachable at `https://analytics.example.com`, and the stats page at
+`https://analytics.example.com/stats?token=$STATS_TOKEN`.
+
+## Point the docs at it
+
+The Docusaurus beacon is already wired (see `apps/docs`). It only activates when
+the docs are **built with** `DOCS_ANALYTICS_URL` set to your collector's
+`/collect` endpoint:
+
+```bash
+DOCS_ANALYTICS_URL=https://analytics.example.com/collect npm run build   # in apps/docs
+```
+
+(The GitHub Pages deploy workflow sets this from a repository variable; without it
+the beacon is a no-op, so local dev and PR builds never phone home.)
+
+## Local development
+
+```bash
+npm install
+STATS_TOKEN=dev npm run dev      # http://localhost:8787
+# send a test beacon:
+curl -XPOST localhost:8787/collect -d '{"path":"/docs/intro","referrer":"https://news.example/"}'
+open http://localhost:8787/stats?token=dev
+```

--- a/apps/docs-analytics/docker-compose.yml
+++ b/apps/docs-analytics/docker-compose.yml
@@ -1,0 +1,26 @@
+# docs-analytics collector — run on your own VPS (no third-party services).
+#
+#   1. export STATS_TOKEN=$(node -e "console.log(require('crypto').randomBytes(24).toString('base64url'))")
+#   2. docker compose up --build -d
+#   3. put it behind your TLS reverse proxy (nginx/Caddy) and point the docs
+#      build at it:  DOCS_ANALYTICS_URL=https://analytics.example.com/collect
+#
+# View stats:  https://analytics.example.com/stats?token=$STATS_TOKEN
+
+services:
+  docs-analytics:
+    build: .
+    image: openbucket-docs-analytics:local
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8787:8787" # bind to loopback; expose via your reverse proxy
+    volumes:
+      - docs-analytics-data:/data
+    environment:
+      ALLOWED_ORIGIN: ${ALLOWED_ORIGIN:-https://projectbay.github.io}
+      STATS_TOKEN: ${STATS_TOKEN:?set STATS_TOKEN in your environment}
+      RETENTION_DAYS: "365"
+      TRUST_PROXY: "true"
+
+volumes:
+  docs-analytics-data:

--- a/apps/docs-analytics/package-lock.json
+++ b/apps/docs-analytics/package-lock.json
@@ -1,0 +1,514 @@
+{
+  "name": "openbucket-docs-analytics",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openbucket-docs-analytics",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "^11.0.0"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.0",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/apps/docs-analytics/package.json
+++ b/apps/docs-analytics/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "openbucket-docs-analytics",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Tiny cookieless, first-party analytics collector for the OpenBucket docs site — no third-party services.",
+  "license": "MIT",
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "dev": "node --watch --experimental-strip-types src/server.ts"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.0.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/apps/docs-analytics/src/config.ts
+++ b/apps/docs-analytics/src/config.ts
@@ -1,0 +1,35 @@
+// Runtime configuration, read once from the environment at startup.
+
+export interface Config {
+  port: number;
+  dbPath: string;
+  /** Docs-site origin allowed to POST pageviews; '*' accepts any origin. */
+  allowedOrigin: string;
+  /** Bearer token required to read /stats; null ⇒ stats endpoint disabled. */
+  statsToken: string | null;
+  /** Raw events older than this many days are pruned nightly. */
+  retentionDays: number;
+  /** Trust X-Forwarded-For for the client IP (behind a reverse proxy). */
+  trustProxy: boolean;
+  /** Max accepted beacon body size, in bytes. */
+  maxBodyBytes: number;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+export function loadConfig(): Config {
+  return {
+    port: envInt('PORT', 8787),
+    dbPath: process.env.DB_PATH ?? './analytics.db',
+    allowedOrigin: process.env.ALLOWED_ORIGIN ?? '*',
+    statsToken: process.env.STATS_TOKEN?.trim() || null,
+    retentionDays: envInt('RETENTION_DAYS', 365),
+    trustProxy: (process.env.TRUST_PROXY ?? 'true') !== 'false',
+    maxBodyBytes: envInt('MAX_BODY_BYTES', 2048),
+  };
+}

--- a/apps/docs-analytics/src/db.ts
+++ b/apps/docs-analytics/src/db.ts
@@ -1,0 +1,147 @@
+// SQLite storage. Raw pageview events + a per-day rotating salt used to derive
+// cookieless visitor hashes. No raw IPs or personal data are ever stored.
+
+import Database from 'better-sqlite3';
+import { randomBytes } from 'node:crypto';
+
+export interface EventInput {
+  ts: number;
+  day: string;
+  path: string;
+  referrer: string;
+  visitor: string;
+  screenW: number;
+  tz: string;
+}
+
+export interface Bucket {
+  key: string;
+  views: number;
+  uniques: number;
+}
+
+export interface Stats {
+  days: number;
+  since: string;
+  totalViews: number;
+  totalUniques: number;
+  topPaths: Bucket[];
+  topReferrers: Bucket[];
+  perDay: Bucket[];
+}
+
+export class Store {
+  private readonly db: Database.Database;
+
+  constructor(dbPath: string) {
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('busy_timeout = 5000');
+    this.migrate();
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS events (
+        id       INTEGER PRIMARY KEY,
+        ts       INTEGER NOT NULL,
+        day      TEXT    NOT NULL,
+        path     TEXT    NOT NULL,
+        referrer TEXT    NOT NULL,
+        visitor  TEXT    NOT NULL,
+        screen_w INTEGER NOT NULL DEFAULT 0,
+        tz       TEXT    NOT NULL DEFAULT ''
+      );
+      CREATE INDEX IF NOT EXISTS idx_events_day  ON events(day);
+      CREATE INDEX IF NOT EXISTS idx_events_path ON events(day, path);
+
+      CREATE TABLE IF NOT EXISTS daily_salt (
+        day   TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `);
+  }
+
+  /**
+   * The salt for a UTC day, created on first use and reused for the rest of the
+   * day. Rotating it daily means a visitor hash can't be correlated across days.
+   */
+  dailySalt(day: string): string {
+    const row = this.db
+      .prepare('SELECT value FROM daily_salt WHERE day = ?')
+      .get(day) as { value: string } | undefined;
+    if (row) return row.value;
+    const value = randomBytes(32).toString('hex');
+    // INSERT OR IGNORE guards the (rare) concurrent-first-write race.
+    this.db
+      .prepare('INSERT OR IGNORE INTO daily_salt (day, value) VALUES (?, ?)')
+      .run(day, value);
+    const stored = this.db
+      .prepare('SELECT value FROM daily_salt WHERE day = ?')
+      .get(day) as { value: string };
+    return stored.value;
+  }
+
+  record(e: EventInput): void {
+    this.db
+      .prepare(
+        `INSERT INTO events (ts, day, path, referrer, visitor, screen_w, tz)
+         VALUES (@ts, @day, @path, @referrer, @visitor, @screenW, @tz)`,
+      )
+      .run(e);
+  }
+
+  /** Delete raw events (and stale salts) older than the retention window. */
+  prune(retentionDays: number): number {
+    const cutoff = dayString(Date.now() - retentionDays * 86_400_000);
+    const info = this.db.prepare('DELETE FROM events WHERE day < ?').run(cutoff);
+    this.db.prepare('DELETE FROM daily_salt WHERE day < ?').run(cutoff);
+    return info.changes;
+  }
+
+  stats(days: number): Stats {
+    const since = dayString(Date.now() - (days - 1) * 86_400_000);
+    const totals = this.db
+      .prepare(
+        `SELECT COUNT(*) AS views, COUNT(DISTINCT visitor) AS uniques
+         FROM events WHERE day >= ?`,
+      )
+      .get(since) as { views: number; uniques: number };
+
+    const group = (col: string, limit: number): Bucket[] =>
+      this.db
+        .prepare(
+          `SELECT ${col} AS key, COUNT(*) AS views, COUNT(DISTINCT visitor) AS uniques
+           FROM events WHERE day >= ?
+           GROUP BY ${col} ORDER BY views DESC, key ASC LIMIT ?`,
+        )
+        .all(since, limit) as Bucket[];
+
+    const perDay = this.db
+      .prepare(
+        `SELECT day AS key, COUNT(*) AS views, COUNT(DISTINCT visitor) AS uniques
+         FROM events WHERE day >= ?
+         GROUP BY day ORDER BY day ASC`,
+      )
+      .all(since) as Bucket[];
+
+    return {
+      days,
+      since,
+      totalViews: totals.views,
+      totalUniques: totals.uniques,
+      topPaths: group('path', 25),
+      topReferrers: group('referrer', 25),
+      perDay,
+    };
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}
+
+/** UTC day (YYYY-MM-DD) for an epoch-ms timestamp. */
+export function dayString(ts: number): string {
+  return new Date(ts).toISOString().slice(0, 10);
+}

--- a/apps/docs-analytics/src/server.ts
+++ b/apps/docs-analytics/src/server.ts
@@ -1,0 +1,196 @@
+// Tiny cookieless, first-party pageview collector for the OpenBucket docs site.
+//
+//   POST /collect     ← the Docusaurus beacon (text/plain JSON body)
+//   GET  /stats       → HTML dashboard   (bearer token)
+//   GET  /stats.json  → JSON             (bearer token)
+//   GET  /health      → "ok"
+//
+// Privacy: the client IP and User-Agent are combined with a per-day rotating
+// salt and hashed (SHA-256) to a visitor id used only for de-duplication; the
+// raw IP is never stored. No cookies, no cross-day correlation, no PII.
+
+import http from 'node:http';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { loadConfig } from './config.js';
+import { Store, dayString } from './db.js';
+import { renderDashboard } from './stats-page.js';
+
+const cfg = loadConfig();
+const store = new Store(cfg.dbPath);
+
+// Prune on boot, then daily. unref() so the timer never keeps the process alive.
+store.prune(cfg.retentionDays);
+setInterval(() => store.prune(cfg.retentionDays), 86_400_000).unref();
+
+const BOT_RE = /bot|crawl|spider|slurp|preview|monitor|headless|lighthouse|pingdom|uptime/i;
+
+function clientIp(req: http.IncomingMessage): string {
+  if (cfg.trustProxy) {
+    const xff = req.headers['x-forwarded-for'];
+    const first = Array.isArray(xff) ? xff[0] : xff;
+    if (first) return first.split(',')[0]!.trim();
+  }
+  return req.socket.remoteAddress ?? '';
+}
+
+function sanitizePath(p: unknown): string {
+  if (typeof p !== 'string' || p.length === 0) return '/';
+  let s = p.split('?')[0]!.split('#')[0]!;
+  if (!s.startsWith('/')) s = '/' + s;
+  return s.slice(0, 512);
+}
+
+function referrerHost(r: unknown): string {
+  if (typeof r !== 'string' || r === '') return 'direct';
+  try {
+    return new URL(r).host.slice(0, 255) || 'direct';
+  } catch {
+    return 'other';
+  }
+}
+
+function clampInt(v: unknown, min: number, max: number): number {
+  const n = typeof v === 'number' ? v : Number.parseInt(String(v), 10);
+  if (!Number.isFinite(n)) return 0;
+  return Math.min(max, Math.max(min, Math.trunc(n)));
+}
+
+function tokenOk(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function handleCollect(req: http.IncomingMessage, res: http.ServerResponse): void {
+  const origin = req.headers.origin;
+  if (cfg.allowedOrigin !== '*' && origin && origin !== cfg.allowedOrigin) {
+    res.writeHead(403).end();
+    return;
+  }
+  res.setHeader('Access-Control-Allow-Origin', cfg.allowedOrigin === '*' ? (origin ?? '*') : cfg.allowedOrigin);
+  res.setHeader('Vary', 'Origin');
+
+  if (req.method === 'OPTIONS') {
+    res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+    res.setHeader('Access-Control-Max-Age', '86400');
+    res.writeHead(204).end();
+    return;
+  }
+  if (req.method !== 'POST') {
+    res.writeHead(405).end();
+    return;
+  }
+
+  const chunks: Buffer[] = [];
+  let size = 0;
+  let aborted = false;
+  req.on('data', (c: Buffer) => {
+    size += c.length;
+    if (size > cfg.maxBodyBytes) {
+      aborted = true;
+      res.writeHead(413).end();
+      req.destroy();
+      return;
+    }
+    chunks.push(c);
+  });
+  req.on('error', () => {});
+  req.on('end', () => {
+    if (aborted) return;
+    // Acknowledge immediately; a beacon must never see an error or block the page.
+    res.writeHead(204).end();
+    try {
+      const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>;
+      const ua = String(req.headers['user-agent'] ?? '').slice(0, 512);
+      if (BOT_RE.test(ua)) return; // drop obvious bots / synthetic checks
+      const ts = Date.now();
+      const day = dayString(ts);
+      const salt = store.dailySalt(day);
+      const visitor = createHash('sha256')
+        .update(`${clientIp(req)}|${ua}|${salt}`)
+        .digest('hex');
+      store.record({
+        ts,
+        day,
+        path: sanitizePath(body.path),
+        referrer: referrerHost(body.referrer),
+        visitor,
+        screenW: clampInt(body.screenW, 0, 20000),
+        tz: typeof body.tz === 'string' ? body.tz.slice(0, 64) : '',
+      });
+    } catch {
+      // ignore malformed beacons
+    }
+  });
+}
+
+function handleStats(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  url: URL,
+  asJson: boolean,
+): void {
+  if (!cfg.statsToken) {
+    res.writeHead(503, { 'content-type': 'text/plain' }).end('STATS_TOKEN is not configured\n');
+    return;
+  }
+  const auth = String(req.headers.authorization ?? '');
+  const provided = auth.startsWith('Bearer ')
+    ? auth.slice(7)
+    : (url.searchParams.get('token') ?? '');
+  if (!tokenOk(provided, cfg.statsToken)) {
+    res.setHeader('WWW-Authenticate', 'Bearer');
+    res.writeHead(401, { 'content-type': 'text/plain' }).end('unauthorized\n');
+    return;
+  }
+  const days = clampInt(url.searchParams.get('days') ?? 30, 1, 3650) || 30;
+  const stats = store.stats(days);
+  if (asJson) {
+    res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' }).end(
+      JSON.stringify(stats, null, 2),
+    );
+  } else {
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' }).end(
+      renderDashboard(stats, days),
+    );
+  }
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  switch (url.pathname) {
+    case '/collect':
+      return handleCollect(req, res);
+    case '/stats':
+      if (req.method !== 'GET') return void res.writeHead(405).end();
+      return handleStats(req, res, url, false);
+    case '/stats.json':
+      if (req.method !== 'GET') return void res.writeHead(405).end();
+      return handleStats(req, res, url, true);
+    case '/health':
+      return void res.writeHead(200, { 'content-type': 'text/plain' }).end('ok\n');
+    default:
+      return void res.writeHead(404, { 'content-type': 'text/plain' }).end('not found\n');
+  }
+});
+
+server.requestTimeout = 15_000;
+server.headersTimeout = 10_000;
+
+server.listen(cfg.port, () => {
+  // eslint-disable-next-line no-console
+  console.log(
+    `docs-analytics collector listening on :${cfg.port} ` +
+      `(db=${cfg.dbPath}, origin=${cfg.allowedOrigin}, stats=${cfg.statsToken ? 'on' : 'disabled'})`,
+  );
+});
+
+for (const sig of ['SIGINT', 'SIGTERM'] as const) {
+  process.on(sig, () => {
+    server.close(() => {
+      store.close();
+      process.exit(0);
+    });
+  });
+}

--- a/apps/docs-analytics/src/stats-page.ts
+++ b/apps/docs-analytics/src/stats-page.ts
@@ -1,0 +1,108 @@
+// Renders the /stats dashboard as a single self-contained HTML document
+// (inline CSS, no external requests — CSP- and offline-friendly).
+
+import type { Bucket, Stats } from './db.js';
+
+function esc(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[
+        c
+      ] as string,
+  );
+}
+
+function rows(items: Bucket[], label: string): string {
+  if (items.length === 0) return `<tr><td colspan="3" class="empty">no data yet</td></tr>`;
+  const max = Math.max(...items.map((i) => i.views), 1);
+  return items
+    .map((i) => {
+      const pct = Math.round((i.views / max) * 100);
+      return `<tr>
+        <td class="key"><span class="bar" style="width:${pct}%"></span><span class="lbl" title="${esc(i.key)}">${esc(i.key)}</span></td>
+        <td class="num">${i.views.toLocaleString('en-US')}</td>
+        <td class="num">${i.uniques.toLocaleString('en-US')}</td>
+      </tr>`;
+    })
+    .join('');
+}
+
+function perDayChart(perDay: Bucket[]): string {
+  if (perDay.length === 0) return `<p class="empty">no data yet</p>`;
+  const max = Math.max(...perDay.map((d) => d.views), 1);
+  return `<div class="chart" role="img" aria-label="Pageviews per day">
+    ${perDay
+      .map((d) => {
+        const h = Math.max(2, Math.round((d.views / max) * 100));
+        return `<div class="col" title="${esc(d.key)}: ${d.views} views / ${d.uniques} visitors">
+          <div class="colbar" style="height:${h}%"></div>
+        </div>`;
+      })
+      .join('')}
+  </div>
+  <div class="chart-axis"><span>${esc(perDay[0]!.key)}</span><span>${esc(perDay[perDay.length - 1]!.key)}</span></div>`;
+}
+
+export function renderDashboard(s: Stats, days: number): string {
+  return `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>OpenBucket docs — traffic</title>
+<style>
+  :root { color-scheme: light dark; --bg:#fff; --fg:#111827; --muted:#6b7280; --line:#e5e7eb; --accent:#2a7ae2; --bar:#dbeafe; }
+  @media (prefers-color-scheme: dark) { :root { --bg:#0b0f14; --fg:#e5e7eb; --muted:#9ca3af; --line:#1f2937; --accent:#60a5fa; --bar:#14304f; } }
+  * { box-sizing: border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg); font:15px/1.5 -apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; }
+  .wrap { max-width: 920px; margin: 0 auto; padding: 32px 20px 64px; }
+  h1 { font-size: 20px; margin: 0 0 2px; }
+  .sub { color: var(--muted); font-size: 13px; margin: 0 0 24px; }
+  .kpis { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 28px; }
+  .kpi { flex: 1 1 160px; border: 1px solid var(--line); border-radius: 12px; padding: 16px 18px; }
+  .kpi .n { font-size: 30px; font-weight: 700; letter-spacing: -0.02em; }
+  .kpi .t { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+  .card { border: 1px solid var(--line); border-radius: 12px; padding: 18px 20px; margin-bottom: 22px; }
+  .card h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); margin: 0 0 14px; }
+  table { width: 100%; border-collapse: collapse; }
+  td { padding: 7px 8px; border-bottom: 1px solid var(--line); vertical-align: middle; }
+  tr:last-child td { border-bottom: 0; }
+  td.key { position: relative; max-width: 0; }
+  .bar { position: absolute; inset: 2px auto 2px 0; background: var(--bar); border-radius: 4px; z-index: 0; }
+  .lbl { position: relative; z-index: 1; display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-variant-numeric: tabular-nums; }
+  td.num { text-align: right; width: 84px; font-variant-numeric: tabular-nums; color: var(--fg); }
+  thead td { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .04em; border-bottom: 1px solid var(--line); }
+  .empty { color: var(--muted); font-style: italic; }
+  .chart { display: flex; align-items: flex-end; gap: 3px; height: 120px; }
+  .col { flex: 1 1 0; display: flex; align-items: flex-end; height: 100%; }
+  .colbar { width: 100%; background: var(--accent); border-radius: 3px 3px 0 0; opacity: .85; }
+  .chart-axis { display: flex; justify-content: space-between; color: var(--muted); font-size: 11px; margin-top: 6px; }
+  footer { color: var(--muted); font-size: 12px; margin-top: 8px; }
+  code { background: var(--line); padding: 1px 5px; border-radius: 4px; font-size: 12px; }
+</style></head>
+<body><div class="wrap">
+  <h1>OpenBucket docs — traffic</h1>
+  <p class="sub">Last ${days} days (since ${esc(s.since)}, UTC) · cookieless, first-party · no third-party services</p>
+
+  <div class="kpis">
+    <div class="kpi"><div class="n">${s.totalViews.toLocaleString('en-US')}</div><div class="t">Pageviews</div></div>
+    <div class="kpi"><div class="n">${s.totalUniques.toLocaleString('en-US')}</div><div class="t">Unique visitors</div></div>
+    <div class="kpi"><div class="n">${s.perDay.length.toLocaleString('en-US')}</div><div class="t">Days with traffic</div></div>
+  </div>
+
+  <div class="card"><h2>Pageviews per day</h2>${perDayChart(s.perDay)}</div>
+
+  <div class="card"><h2>Top pages</h2>
+    <table><thead><tr><td>Path</td><td class="num">Views</td><td class="num">Uniq</td></tr></thead>
+    <tbody>${rows(s.topPaths, 'path')}</tbody></table>
+  </div>
+
+  <div class="card"><h2>Top referrers</h2>
+    <table><thead><tr><td>Referrer</td><td class="num">Views</td><td class="num">Uniq</td></tr></thead>
+    <tbody>${rows(s.topReferrers, 'referrer')}</tbody></table>
+  </div>
+
+  <footer>Machine-readable: <code>GET /stats.json?days=${days}</code> (same bearer token).</footer>
+</div></body></html>`;
+}

--- a/apps/docs-analytics/tsconfig.json
+++ b/apps/docs-analytics/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -4,6 +4,16 @@
 // See: https://docusaurus.io/docs/api/docusaurus-config
 
 import {themes as prismThemes} from 'prism-react-renderer';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// First-party, cookieless pageview analytics (self-hosted collector — see
+// apps/docs-analytics). The beacon activates only when the docs are built with
+// DOCS_ANALYTICS_URL pointing at the collector's /collect endpoint; otherwise it
+// is a complete no-op, so local dev and PR/preview builds never phone home.
+const analyticsUrl = process.env.DOCS_ANALYTICS_URL;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -26,6 +36,28 @@ const config = {
   baseUrl: '/openbucket/',
   organizationName: 'ProjectBay',
   projectName: 'openbucket',
+
+  // Cookieless, first-party pageview beacon (no-op unless DOCS_ANALYTICS_URL is set).
+  clientModules: [path.resolve(dirname, 'src/analytics-beacon.js')],
+
+  plugins: [
+    // Expose the collector URL to the beacon as a runtime global, but only when
+    // DOCS_ANALYTICS_URL was set at build time.
+    function docsAnalyticsPlugin() {
+      return {
+        name: 'openbucket-docs-analytics',
+        injectHtmlTags() {
+          if (!analyticsUrl) return {};
+          const json = JSON.stringify({url: analyticsUrl}).replace(/</g, '\\u003c');
+          return {
+            headTags: [
+              {tagName: 'script', innerHTML: `window.__OB_DOCS_ANALYTICS__=${json};`},
+            ],
+          };
+        },
+      };
+    },
+  ],
 
   // 'warn' (not 'throw') because the ported whitepaper carries repo-relative
   // links (source paths, sibling design docs) that don't all resolve in-site.

--- a/apps/docs/src/analytics-beacon.js
+++ b/apps/docs/src/analytics-beacon.js
@@ -1,0 +1,41 @@
+// Cookieless, first-party pageview beacon for the OpenBucket docs site.
+//
+// Sends an anonymous ping to the self-hosted collector whose URL is injected at
+// build time from `DOCS_ANALYTICS_URL` (see docusaurus.config.js) and exposed as
+// `window.__OB_DOCS_ANALYTICS__`. It is a complete no-op when that is unset — so
+// local dev and PR/preview builds never phone home — and it honors Do Not Track.
+//
+// No cookies, no localStorage, no identifiers are set client-side.
+
+export function onRouteDidUpdate({ location, previousLocation }) {
+  if (typeof window === 'undefined' || typeof navigator === 'undefined') return;
+
+  // A hash/query-only change to the same page is not a new pageview.
+  if (previousLocation && previousLocation.pathname === location.pathname) return;
+
+  const cfg = window.__OB_DOCS_ANALYTICS__;
+  if (!cfg || !cfg.url) return;
+
+  // Respect Do Not Track.
+  const dnt = navigator.doNotTrack || window.doNotTrack;
+  if (dnt === '1' || dnt === 'yes') return;
+
+  try {
+    const payload = JSON.stringify({
+      path: location.pathname,
+      referrer: document.referrer || '',
+      screenW: (window.screen && window.screen.width) || 0,
+      tz: Intl.DateTimeFormat().resolvedOptions().timeZone || '',
+    });
+    if (navigator.sendBeacon) {
+      // A string body is sent as text/plain → a CORS "simple request" (no preflight).
+      navigator.sendBeacon(cfg.url, payload);
+    } else {
+      fetch(cfg.url, { method: 'POST', body: payload, keepalive: true, mode: 'no-cors' }).catch(
+        () => {},
+      );
+    }
+  } catch {
+    // Analytics must never break the page.
+  }
+}


### PR DESCRIPTION
## What

Adds **cookieless, first-party traffic analytics** for the docs site — **no
third-party services**. The Docusaurus site sends an anonymous beacon on each
pageview to a tiny collector **you** run on your VPS; it stores aggregate counts
in SQLite and serves a small stats dashboard.

Two pieces:

- **`apps/docs-analytics/`** — a small standalone Node/TypeScript service (one
  dependency: `better-sqlite3`). Endpoints: `POST /collect`, `GET /stats` (HTML
  dashboard), `GET /stats.json`, `GET /health`. Ships with a `Dockerfile` +
  `docker-compose.yml` + README for a one-command VPS deploy.
- **`apps/docs`** — a cookieless `clientModule` beacon + config wiring. It's a
  **complete no-op** unless the docs are built with `DOCS_ANALYTICS_URL` set, so
  local dev and PR/preview builds never phone home. `deploy-docs.yml` passes it
  from a `DOCS_ANALYTICS_URL` repo variable (unset ⇒ nothing changes).

## Privacy

No cookies, no `localStorage`, no fingerprinting, no PII at rest, honors
`navigator.doNotTrack`. The client IP + User-Agent are combined with a **per-day
rotating salt** and SHA-256 hashed into a visitor id used only for daily
de-duplication — the **raw IP is never stored**, and the daily salt rotation means
a visitor can't be correlated across days. GDPR-friendly with no cookie banner.
Footprint: one small Node process + a SQLite file (no Postgres/ClickHouse).

## Verified locally

- Collector: `npm install` + `tsc` build clean (0 vulns). Ran it and exercised
  every path — `/collect` → `204`, real beacons aggregate correctly
  (`views=3, uniques=2`), **query strings stripped** from paths, **referrer hosts**
  extracted, **bot UA dropped** from stats, oversized body → `413`, `/stats`
  without token → `401`, with token → HTML + JSON.
- Docs: `npm run build` **succeeds** with the beacon wired in; the runtime global
  is injected into the built HTML only when `DOCS_ANALYTICS_URL` is set.

## To turn it on

1. Deploy the collector on the VPS (`apps/docs-analytics/README.md`), behind your
   TLS reverse proxy, with a `STATS_TOKEN`.
2. Set the `DOCS_ANALYTICS_URL` **repository variable** to the collector's
   `/collect` URL. The next docs deploy activates the beacon.
3. View traffic at `https://<collector-host>/stats?token=<STATS_TOKEN>`.

Until step 2, this changes nothing user-facing — the beacon stays dormant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
