### PR TITLE
docs: add Plausible analytics tracking

### DIFF
--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -17,6 +17,17 @@ const config = {
     'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap',
   ],
 
+  // Privacy-friendly, cookieless analytics via our self-hosted Plausible
+  // instance (https://analytics.projectbay.dev). `data-domain` is the site
+  // name registered in Plausible; it matches this docs site's public URL.
+  scripts: [
+    {
+      src: 'https://analytics.projectbay.dev/js/script.js',
+      defer: true,
+      'data-domain': 'projectbay.github.io/openbucket',
+    },
+  ],
+
   future: {
     v4: true, // forward-compat with Docusaurus v4
   },


### PR DESCRIPTION
Adds cookieless, privacy-friendly analytics to the Docusaurus docs site via our self-hosted **Plausible** instance at https://analytics.projectbay.dev.

### What
- Adds a `scripts` entry to `apps/docs/docusaurus.config.js` loading `https://analytics.projectbay.dev/js/script.js` with `data-domain="projectbay.github.io/openbucket"`.

### Before this tracks anything
The site must be registered in the Plausible dashboard with the domain **`projectbay.github.io/openbucket`** (Plausible only records events for sites it knows). Once the site is added there and this is merged + deployed to GitHub Pages, page views start showing up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)