### PR TITLE
docs(seo): wire config to social card + page descriptions (follow-up to #42)

### DIFF
--- a/apps/docs/docs/contributing.md
+++ b/apps/docs/docs/contributing.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 6
 title: Contributing
+description: How to contribute to OpenBucket — local dev setup, the Node 22 toolchain, the Nx monorepo workflow, tests, and the pull-request process.
 ---
 
 # Contributing to OpenBucket

--- a/apps/docs/docs/reference/nestjs-module.md
+++ b/apps/docs/docs/reference/nestjs-module.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 6
 title: NestJS module reference
+description: Full API reference for @openbucket/nestjs — embed an S3-compatible object store (wire protocol, admin API, admin console SPA) inside your NestJS app.
 ---
 
 # NestJS module reference

--- a/apps/docs/docs/whitepaper/00-front-matter.md
+++ b/apps/docs/docs/whitepaper/00-front-matter.md
@@ -1,3 +1,7 @@
+---
+description: OpenBucket implementation white paper — how the single-container, single-process, S3-compatible object store is built, section by section.
+---
+
 # OpenBucket — Implementation White Paper
 
 > **Status:** implementation plan (v1). This document specifies *how* OpenBucket is built, in enough detail that a senior engineer can implement directly from it. It is the operational sibling of `ARCHITECTURE.md` (the *what*) and supersedes `BACKEND-DESIGN.md` (the summary-level *how*) at the level of code.

--- a/apps/docs/docs/whitepaper/01-backend-architecture.md
+++ b/apps/docs/docs/whitepaper/01-backend-architecture.md
@@ -1,3 +1,7 @@
+---
+description: OpenBucket backend architecture — how a single NestJS process boots and multiplexes S3, admin API, and SPA traffic onto one port.
+---
+
 # 1. Backend Architecture & Bootstrap
 
 This section specifies the structural backbone of the OpenBucket backend: how the single Node process boots, how one Nest application multiplexes three traffic types onto port 9000, and which scaffolding pieces every downstream subsystem can assume is already in place. Subsystem internals — S3 wire handling [see §3], persistence and the blob store [see §2], streaming and background ticks [see §4], the frontend [see §5] — are deliberately out of scope here. What is in scope is everything they hang off.

--- a/apps/docs/docs/whitepaper/02-s3-protocol-and-sigv4.md
+++ b/apps/docs/docs/whitepaper/02-s3-protocol-and-sigv4.md
@@ -1,3 +1,7 @@
+---
+description: How OpenBucket implements the Amazon S3 wire protocol and AWS Signature V4 auth — request routing, XML parsing, error envelopes, and every S3 operation.
+---
+
 # 2. S3 Wire Protocol & SigV4 Authentication
 
 This section specifies the S3 surface of OpenBucket end-to-end: how requests are

--- a/apps/docs/docs/whitepaper/03-persistence-and-storage.md
+++ b/apps/docs/docs/whitepaper/03-persistence-and-storage.md
@@ -1,3 +1,7 @@
+---
+description: OpenBucket's persistence layer — a SQLite metadata store and a path-mirrored filesystem blob store kept consistent with atomic, crash-safe writes.
+---
+
 # 3. Persistence & Storage Layer
 
 This section specifies the durable substrate beneath OpenBucket: the SQLite-backed metadata store, the path-mirrored blob store, and the discipline that keeps the two consistent across crashes. Everything here is single-process, single-host, single-volume. There is no distributed locking, no replication, no quorum — just one Node process, one event loop, one filesystem, one SQLite file, and a small set of rules that make atomic writes possible.

--- a/apps/docs/docs/whitepaper/04-streaming-and-concurrency.md
+++ b/apps/docs/docs/whitepaper/04-streaming-and-concurrency.md
@@ -1,3 +1,7 @@
+---
+description: OpenBucket streaming I/O and concurrency — the byte plumbing for S3 PUT/GET/Range/multipart plus the in-process scheduler for background work.
+---
+
 # 4. Streaming I/O, Concurrency & Background Work
 
 This section is the implementation layer between the HTTP server (handled by the *backend-architect agent*) and the persistence layer (handled by the *persistence agent*). It owns the **byte plumbing** for the S3 object hot path — PUT, GET, Range, multipart — plus the **in-process scheduler** that drives lifecycle, multipart cleanup, trash purge, and orphan scans.

--- a/apps/docs/docs/whitepaper/05-admin-frontend-auth-delivery.md
+++ b/apps/docs/docs/whitepaper/05-admin-frontend-auth-delivery.md
@@ -1,3 +1,7 @@
+---
+description: OpenBucket's admin JSON API, Angular admin console, JWT auth flow, and the build pipeline that ships both in a single Docker image.
+---
+
 # 5. Admin API, Frontend, Auth Flow & Delivery
 
 This section specifies the JSON admin API that lives at `/api/admin/*`, the Angular SPA that lives at `/admin/*`, the authentication flow that ties them together, and the build pipeline that produces the single Docker image carrying both. The S3 wire protocol (everything else on port 9000) is owned by the S3 agent and only referenced where its boundary touches admin code.

--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -71,14 +71,57 @@ const config = {
         theme: {
           customCss: './src/css/custom.css',
         },
+        sitemap: {
+          lastmod: 'date',
+          changefreq: 'weekly',
+          priority: 0.5,
+          filename: 'sitemap.xml',
+        },
       }),
     ],
+  ],
+
+  // Structured data (JSON-LD) — describes the project to search engines as a
+  // SoftwareApplication so it can qualify for richer results.
+  headTags: [
+    {
+      tagName: 'script',
+      attributes: {type: 'application/ld+json'},
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'SoftwareApplication',
+        name: 'OpenBucket',
+        applicationCategory: 'DeveloperApplication',
+        operatingSystem: 'Linux, macOS, Windows, Docker',
+        description:
+          'A self-hosted, S3-compatible object store you can run as a container — or embed in a NestJS app. Speaks the Amazon S3 wire protocol (SigV4, presigned URLs, multipart, versioning, object lock) from a single Node.js process.',
+        url: 'https://projectbay.github.io/openbucket/',
+        license: 'https://opensource.org/licenses/MIT',
+        codeRepository: 'https://github.com/ProjectBay/openbucket',
+        offers: {
+          '@type': 'Offer',
+          price: '0',
+          priceCurrency: 'USD',
+        },
+      }),
+    },
   ],
 
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      image: 'img/docusaurus-social-card.jpg',
+      // Default Open Graph / Twitter share image (branded 1200×630 card).
+      image: 'img/openbucket-social-card.png',
+      // Global <meta> tags. Docusaurus already emits og:* and twitter:card
+      // (summary_large_image, from `image` above); this adds keywords + author.
+      metadata: [
+        {
+          name: 'keywords',
+          content:
+            'S3-compatible, object store, self-hosted, NestJS, S3 API, SigV4, presigned URLs, MinIO alternative, self-hosted S3, Docker, Node.js, TypeScript',
+        },
+        {name: 'author', content: 'OpenBucket contributors'},
+      ],
       colorMode: {
         respectPrefersColorScheme: true,
       },


### PR DESCRIPTION
Completes the SEO work. #42 shipped the branded social-card asset, `robots.txt`, and the generator, but a partial commit left out the config that references them plus the page-description frontmatter — so the live site still served the old `og:image` with no keywords/JSON-LD. This adds the missing half.

## Changes
- Point `themeConfig.image` at `openbucket-social-card.png` (was still the stock `docusaurus-social-card.jpg`).
- Add `keywords` + `author` `<meta>` and the `SoftwareApplication` JSON-LD `headTags`.
- Configure the sitemap plugin explicitly (`lastmod` / weekly / priority).
- Fill the 8 docs missing `description:` frontmatter.

Plausible (#41) is left untouched — verified still present in the config.

## Verification
Local `npx docusaurus build` confirms the built `docs/intro/index.html` now carries the new `og:image`, keywords, and `SoftwareApplication` JSON-LD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)