### PR TITLE
docs: comparison, fit-guide, roadmap & security-audit trust pages

### DIFF
--- a/apps/docs/docs/comparisons/_category_.json
+++ b/apps/docs/docs/comparisons/_category_.json
@@ -1,0 +1,12 @@
+{
+  "label": "Comparisons",
+  "position": 4.5,
+  "collapsible": true,
+  "collapsed": true,
+  "link": {
+    "type": "generated-index",
+    "slug": "/comparisons",
+    "title": "Comparisons",
+    "description": "How OpenBucket compares to other S3-compatible object stores — so you can pick the right tool for the job."
+  }
+}

--- a/apps/docs/docs/comparisons/vs-minio.md
+++ b/apps/docs/docs/comparisons/vs-minio.md
@@ -1,0 +1,110 @@
+---
+title: OpenBucket vs MinIO
+description: An honest comparison of OpenBucket and MinIO — a single-process, embeddable S3 store vs a distributed object-storage cluster. When to pick each.
+sidebar_position: 1
+keywords: [openbucket vs minio, minio alternative, self-hosted s3, embeddable s3, minio vs]
+---
+
+# OpenBucket vs MinIO
+
+Both OpenBucket and [MinIO](https://min.io) speak the Amazon S3 wire protocol and
+can be self-hosted. They solve **different problems**, and the honest answer to
+"which should I use?" is: it depends on whether you're building _one application_
+or operating _storage for an organization_.
+
+## TL;DR
+
+- **Choose MinIO** if you need a **distributed, horizontally-scalable** object
+  store — multi-node, erasure coding, high availability, petabyte capacity. It's
+  battle-tested infrastructure for a storage _tier_.
+- **Choose OpenBucket** if you're **building an app** that needs file storage and
+  you'd rather not run a separate storage service at all — especially on
+  **NestJS**, where OpenBucket installs as an npm module and runs _inside your
+  process_. One node, your disk, dead-simple ops.
+
+They're not really competitors so much as different tools. If you outgrow a single
+node, OpenBucket can even [replicate or tier to a MinIO cluster](../guides/replication-and-tiering.md).
+
+## At a glance
+
+| | **OpenBucket** | **MinIO** |
+| --- | --- | --- |
+| **Architecture** | Single Node.js process, SQLite + filesystem | Distributed Go servers, erasure-coded across nodes/drives |
+| **Runs inside your app** | ✅ `@openbucket/nestjs` mounts in-process | ❌ Always a separate service |
+| **Deployment** | One container **or** one npm dependency | A server/cluster to run and operate |
+| **Horizontal scale / HA** | ❌ Single node by design | ✅ Multi-node, high availability |
+| **Durability model** | Atomic writes + per-object SHA-256 + bit-rot scrubber; **async replication** to real S3/R2/B2 for off-box copies | Erasure coding + multi-node redundancy |
+| **App-layer tooling** | ✅ multer engine, presigned POST helper, in-process object events, on-the-fly image transforms | ❌ (client SDK only) |
+| **Admin console** | ✅ Full Angular console, MIT | ✅ Console (feature set varies by build) |
+| **License** | **MIT** | **AGPLv3** |
+| **Best for** | One app / homelab / dev-test / edge / SaaS file backend | Storage tier for a team or org; large-scale, HA workloads |
+| **Maturity** | Pre-1.0, feature-complete S3 surface, audited | Mature, widely deployed |
+
+## Where OpenBucket wins
+
+- **It embeds in your application.** No other mainstream S3 store runs _inside_
+  your Node process. With `@openbucket/nestjs`, `npm install` plus one module
+  gives you an S3 endpoint, an admin console, and app-layer upload tooling — no
+  second service, no container to babysit in local dev.
+- **App-layer developer experience.** A one-line
+  [multer storage engine](../guides/file-uploads.md), a
+  [presigned-POST helper](../guides/sharing-files.md), in-process
+  `@OnObjectCreated()` events, and [on-the-fly image transforms](../guides/image-transforms.md)
+  (`?w=&h=&format=webp`) — things a _remote_ S3 fundamentally can't do, because
+  they require living in the request path.
+- **Operational simplicity.** One process, one volume. Nothing to cluster,
+  quorum, or rebalance.
+- **MIT-licensed**, including the admin console.
+
+## Where MinIO wins
+
+- **Scale and high availability.** MinIO is a distributed system with erasure
+  coding and automatic failover. OpenBucket is single-node — if the node is down,
+  the store is down. For multi-node durability and HA out of the box, MinIO (or a
+  cloud provider) is the right tool.
+- **Maturity at scale.** MinIO has years of production hardening across large
+  fleets. OpenBucket is pre-1.0.
+- **Polyglot / infrastructure use.** If you want a language-agnostic storage tier
+  for many services, a standalone cluster fits better than an embeddable module.
+
+## Choose OpenBucket when…
+
+- You're building an app (especially NestJS) that needs file storage without
+  standing up separate infrastructure.
+- You want local-dev / prod parity from one small engine.
+- A single well-run node — with backups and a replica to real S3/R2/B2 — is an
+  appropriate amount of durability for your data.
+
+## Choose MinIO when…
+
+- You need a multi-node, horizontally-scaled storage cluster or petabyte capacity.
+- You require built-in high availability and quorum durability.
+- You're operating storage as shared infrastructure for many teams/services.
+
+## FAQ
+
+### Is OpenBucket a drop-in replacement for MinIO?
+
+For the S3 _wire protocol_, largely yes — point any S3 SDK at it (path-style). But
+architecturally they differ: OpenBucket is single-node, so it does not replace
+MinIO's distributed, high-availability deployment. See
+[Is OpenBucket for you?](../is-openbucket-for-you.md).
+
+### Can OpenBucket scale like MinIO?
+
+No — OpenBucket is single-node by design. For durability beyond one box it
+[replicates and tiers](../guides/replication-and-tiering.md) to an external
+S3-compatible target (which can be MinIO, AWS S3, Cloudflare R2, or Backblaze B2),
+but it does not shard or cluster.
+
+### Can I use OpenBucket with the AWS SDK / `mc` / `s3cmd`?
+
+Yes. OpenBucket is verified against the AWS SDK, the `aws` CLI, MinIO's `mc`, and
+`s3cmd` in its [conformance suite](../reference/s3-compatibility.md). Use
+path-style addressing (`forcePathStyle: true`).
+
+### Which license does each use?
+
+OpenBucket is **MIT**. MinIO's server is **AGPLv3**. If AGPL's copyleft terms are
+a concern for embedding storage into a proprietary product, that's a point worth
+checking with your team.

--- a/apps/docs/docs/concepts/security-audit-2026.md
+++ b/apps/docs/docs/concepts/security-audit-2026.md
@@ -1,0 +1,63 @@
+---
+title: Security audit (2026)
+description: Summary of the July 2026 white-box security audit of OpenBucket — 22 findings across 13 attack surfaces, all remediated and shipped, each with a regression test.
+sidebar_position: 5
+---
+
+# Security audit (2026)
+
+In July 2026, OpenBucket underwent an independent **white-box security audit**
+before its first tagged releases. We're publishing the result in full — including
+the critical finding — because for a store that holds your data, an audit you
+survived _transparently_ is worth more than silence.
+
+## Scope
+
+The audit reviewed **13 attack surfaces** with independent adversarial
+verification of every finding:
+
+> SigV4 auth · admin JWT · path traversal · backup/restore ZIP handling · SPA
+> serving · persistence / SQL injection · XML / XXE · SSE crypto · authorization
+> · denial-of-service · secrets & config · HTTP hardening · supply chain
+
+It confirmed **22 issues: 1 critical, 1 high, 7 medium, 7 low, 6 informational.**
+
+## Result
+
+:::tip All findings remediated
+Every confirmed finding was fixed — each with a regression test — and shipped in
+**`v0.1.0-alpha.8`** (2026-07-04). See the
+[CHANGELOG](https://github.com/ProjectBay/openbucket/blob/main/CHANGELOG.md#010-alpha8--2026-07-04)
+for the full per-finding entry.
+:::
+
+## Findings & remediation
+
+| Severity | Finding | Status |
+| --- | --- | --- |
+| **Critical** | **Unauthenticated admin-API bypass (CWE-178).** The admin JWT guard gated auth on a case-**sensitive** path prefix while Express routes case-**insensitively**, so `GET /api/Admin/backup` reached the admin handler with no token — exposing whole-instance backup download, bucket CRUD, and S3 access-key minting to anonymous callers. | ✅ Fixed in `alpha.8` — the guard now compares case-insensitively and fail-closed; regression tests assert mixed-case admin paths return 401. |
+| **High** | **Stored XSS → admin token theft.** Attacker-controlled object `Content-Type` was served inline on the app origin. | ✅ Fixed — a Content-Security-Policy is enforced and S3 object GETs carry safe `Content-Type` / `Content-Disposition`. |
+| **Medium/Low** | **Bucket policies were stored but inert** (not evaluated). | ✅ Fixed — bucket policies are now evaluated through the same policy engine as scoped keys; explicit `Deny` is enforced (default-allow, so credentialed access is unaffected). |
+| **Medium** | Sessions/refresh tokens not revoked on password change; `mustChangePassword` advisory-only. | ✅ Fixed — revoked on password change; enforced. |
+| **Medium** | Server-side `CopyObject` streamed SSE ciphertext as plaintext. | ✅ Fixed — decrypt-then-re-encrypt on copy. |
+| **Medium** | DoS surface: no request/socket timeouts (slowloris), no storage quota, unbounded restore decompression, unbounded manifest read, no S3 rate limiting, missing `ListParts` pagination. | ✅ Fixed — timeouts restored, storage quota, decompression-bomb + manifest caps, S3 rate limiting, paginated `ListParts`. |
+| **Low** | SigV4 signatures + access-key IDs leaked into logs. | ✅ Fixed — redacted from logs. |
+| **Low** | CORS preflight bucket-existence enumeration oracle. | ✅ Fixed — opaque preflight. |
+| **Low** | `SignedHeaders` coverage of mandatory headers not enforced. | ✅ Fixed — coverage enforced. |
+| **Info** | Aggregate key-length cap; SPA symlink/realpath check; `LIKE`-metacharacter escaping in prefix filters; low-entropy secret rejection; disabled `@scarf/scarf` install telemetry; moved `@nx/nest` out of production dependencies with an `npm audit` CI gate. | ✅ Fixed. |
+
+Backup/restore ZIP handling was reviewed for zip-slip / path-traversal and found
+**correctly closed** (triple validation + key-codec re-encoding).
+
+## Ongoing security posture
+
+- **Coordinated disclosure.** Report vulnerabilities privately per our
+  [SECURITY.md](https://github.com/ProjectBay/openbucket/blob/main/SECURITY.md)
+  (3-day acknowledgement). GitHub Security Advisories are enabled.
+- **CI gates.** Every build runs `npm audit --audit-level=high` and CodeQL
+  (`security-and-quality` query suite).
+- **Out of scope / follow-up.** A formal STRIDE threat model is planned as a
+  future spike. New auth mechanisms (OIDC, full IAM policies) are a future epic.
+
+For the design-level view of how OpenBucket authenticates and authorizes every
+request, see the [Security model](./security-model.md).

--- a/apps/docs/docs/is-openbucket-for-you.md
+++ b/apps/docs/docs/is-openbucket-for-you.md
@@ -1,0 +1,75 @@
+---
+title: Is OpenBucket for you?
+description: An honest fit guide — when a single-node, S3-compatible object store you embed in your app is the right choice, and when to reach for a distributed store instead.
+sidebar_position: 1.5
+---
+
+# Is OpenBucket for you?
+
+OpenBucket is a **single-node** S3-compatible object store: one Node.js process
+over SQLite and the local filesystem. That design is a deliberate trade — it's
+what makes OpenBucket small enough to `docker run` in one command or embed
+directly inside your NestJS app, and it's why it is **not** a drop-in
+replacement for a distributed object store. Be honest with yourself about which
+side of that line you're on.
+
+## OpenBucket is a great fit when…
+
+- **You want S3 semantics without operating a cluster.** One container, one
+  volume, any S3 SDK. No MinIO cluster to run, no AWS bill, no second service to
+  babysit.
+- **You're building an app and need a file backend.** The
+  [`@openbucket/nestjs`](./getting-started/quickstart-embed.md) library runs
+  _inside your process_ — one-line multer uploads, presigned browser POST,
+  in-process `@OnObjectCreated()` events, and on-the-fly image transforms. A
+  remote S3 can't do these in-process.
+- **Your durability needs are "one node, plus a copy off the box."** OpenBucket
+  writes atomically, stores a SHA-256 per object, gates every read against it,
+  and scrubs for bit-rot in the background. For off-box durability you turn on
+  [async replication](./guides/replication-and-tiering.md) to real S3 / R2 / B2
+  / MinIO. That's your redundancy story — see below.
+- **You're self-hosting for cost, sovereignty, air-gap, dev/test, or edge** and
+  a single well-run node with backups and a replica is an appropriate amount of
+  durability for the data.
+- **You want small-to-moderate volumes** that fit comfortably on one machine's
+  disk and one SQLite metadata database.
+
+## OpenBucket is _not_ the right choice when…
+
+- **You need built-in multi-node durability or high availability.** There is
+  **no clustering, sharding, or automatic failover.** The node is a single point
+  of failure for _availability_; if it's down, your store is down until it's
+  back. Replication gives you a durable second copy, not automatic HA. If you
+  require multi-node quorum durability out of the box, use AWS S3, Cloudflare R2,
+  or a MinIO cluster.
+- **You need the eleven-nines, multi-AZ durability SLA of a hyperscaler.**
+  OpenBucket's durability is as good as your disk, your fsync, your backups, and
+  your replica — all of which you operate. We tell you exactly how the bytes are
+  protected ([Durability](./concepts/durability.md)) so you can decide if that's
+  enough. We do not offer a durability SLA.
+- **You need virtual-host-style addressing or region emulation.** Path-style
+  only (`forcePathStyle: true`), one configured region, no cross-region
+  redirects.
+- **You need S3 features we don't implement.** `SelectObjectContent` and
+  `GetObjectTorrent` return `NotImplemented`; accelerate / logging /
+  request-payment / website subresources are recognized stubs, not production
+  features. See the [compatibility matrix](./reference/s3-compatibility.md).
+- **You're at very large scale** — tens of TB / high-concurrency multi-tenant
+  workloads that outgrow a single node and one SQLite metadata plane.
+
+## Running it safely, whatever your case
+
+Even where OpenBucket fits, treat it like the stateful, single-node system it
+is: put it behind a TLS-terminating reverse proxy, keep all of `DATA_DIR` on one
+filesystem (atomic renames depend on it), turn on
+[scheduled backups](./guides/backup-and-restore.md) and, for anything you can't
+afford to lose, [replication](./guides/replication-and-tiering.md) to a second
+target.
+
+:::info Pre-1.0 status
+OpenBucket is pre-1.0. The S3 surface and admin console are feature-complete and
+tested against a [conformance suite](./reference/s3-compatibility.md), and a
+[security audit](./concepts/security-audit-2026.md) has been completed and
+remediated — but APIs may still change before 1.0. See the
+[roadmap](./roadmap.md) for what's stable and what may still move.
+:::

--- a/apps/docs/docs/roadmap.md
+++ b/apps/docs/docs/roadmap.md
@@ -1,0 +1,67 @@
+---
+title: Roadmap
+description: What's stable in OpenBucket today, what may still change before 1.0, and how to influence the direction.
+sidebar_position: 8
+---
+
+# Roadmap
+
+OpenBucket is **pre-1.0 and under active development**. This page is the honest
+picture of what you can rely on today and what may still move before 1.0, so you
+can decide how to adopt.
+
+## Stable today
+
+These are feature-complete and covered by tests / the
+[conformance suite](./reference/s3-compatibility.md):
+
+- **S3 wire protocol** — path-style addressing, SigV4 (header + presigned query),
+  streaming PUT/GET, multipart uploads, object & bucket tagging, versioning,
+  object lock (governance/compliance + legal hold), SSE-S3 encryption, lifecycle
+  expiration, CORS, and bucket policies.
+- **Admin API + console** — the JSON admin API and the bundled Angular console
+  (bucket/object browser, search, preview, access-key & multi-admin management,
+  usage analytics, audit log).
+- **Embedding** — the [`@openbucket/nestjs`](./getting-started/quickstart-embed.md)
+  module, `OpenBucketService`, the multer engine, presigned POST, and in-process
+  object events.
+- **Durability & operations** — [replication](./guides/replication-and-tiering.md),
+  cold-object tiering, [backup & restore](./guides/backup-and-restore.md), the
+  integrity scrubber, Prometheus `/metrics`, and health/readiness probes.
+- **Security** — remediated per the [2026 security audit](./concepts/security-audit-2026.md).
+
+## Stabilizing before 1.0
+
+The **behavior** above is stable; what may still change before 1.0 is at the
+edges:
+
+- **Public API surface** — method signatures on `OpenBucketService` and the
+  `OpenBucketModule` options may be refined. Breaking changes are called out in
+  the [CHANGELOG](https://github.com/ProjectBay/openbucket/blob/main/CHANGELOG.md).
+- **Admin API / generated client** — endpoint shapes may still evolve.
+- **Configuration** — environment-variable names and defaults may be consolidated.
+
+## The 1.0 bar
+
+We consider OpenBucket 1.0 when:
+
+- The public library + admin API surfaces are frozen under semver.
+- The S3 compatibility matrix is backed by a machine-generated, dated conformance
+  report.
+- A stable release sits on the npm `latest` tag (not a pre-release).
+
+## What OpenBucket is deliberately _not_ doing
+
+To keep the "one process, one volume" promise, multi-node clustering, sharding,
+and quorum HA are **out of scope** — that's a different kind of system. For
+durability beyond a single node, OpenBucket replicates and tiers to an external
+S3-compatible target. See [Is OpenBucket for you?](./is-openbucket-for-you.md).
+
+## Influence the direction
+
+- 🗳️ **Feature requests & discussion** →
+  [GitHub Discussions](https://github.com/ProjectBay/openbucket/discussions)
+- 🐛 **Bugs** →
+  [Issues](https://github.com/ProjectBay/openbucket/issues)
+- 🤝 **Contributions** are welcome — see
+  [Contributing](./contributing.md).


### PR DESCRIPTION
Additive docs from the growth audit — new pages only, no changes to existing content or the front-door README.

- **`comparisons/vs-minio.md`** — honest OpenBucket-vs-MinIO comparison (highest-intent evaluation SEO) + FAQ.
- **`is-openbucket-for-you.md`** — candid "when to use / when NOT to use" fit guide.
- **`concepts/security-audit-2026.md`** — public summary of the July 2026 audit (22 findings, 1 critical, all remediated in `alpha.8`, each with a regression test). Grounded in EPIC-08 + the CHANGELOG. Turns the audit into a visible trust asset.
- **`roadmap.md`** — public "what's stable / what may change / the 1.0 bar."

`npx docusaurus build` passes; all four pages build with no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)