### PR TITLE
feat(cli): offline `openbucket hash` command + harden .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,10 +14,13 @@ DATA_DIR=/data
 
 # --- admin auth ---
 # Signs admin JWTs. Use a long random value (>= 32 chars), e.g. `openssl rand -hex 32`.
-JWT_SECRET=change-me-to-a-random-string-at-least-32-chars
+# The REPLACE_ME placeholders below are intentionally INVALID — the app refuses
+# to boot until you set real secrets (so you never ship these by accident).
+JWT_SECRET=REPLACE_ME
 ADMIN_USERNAME=admin
-# argon2id hash of the admin password — generate with:
-#   node scripts/hash-password.mjs 'your-admin-password'
+# argon2id hash of the admin password — generate one with EITHER:
+#   npx @openbucket/nestjs hash 'your-admin-password'    (no repo checkout needed)
+#   node scripts/hash-password.mjs 'your-admin-password' (from a repo clone)
 ADMIN_PASSWORD_HASH=
 # Optional token lifetimes (seconds).
 # JWT_ACCESS_TTL_SECONDS=900
@@ -25,8 +28,9 @@ ADMIN_PASSWORD_HASH=
 
 # --- S3 root credentials (SigV4) ---
 # ACCESS_KEY_ID: 16-32 uppercase alphanumerics. SECRET: >= 32 chars.
-ROOT_ACCESS_KEY_ID=AKIAEXAMPLE000000000
-ROOT_SECRET_ACCESS_KEY=change-me-to-a-random-secret-at-least-32-chars
+# Placeholders again — set real values (the app refuses to boot otherwise).
+ROOT_ACCESS_KEY_ID=REPLACE_ME
+ROOT_SECRET_ACCESS_KEY=REPLACE_ME
 
 # --- S3 options ---
 OPENBUCKET_REGION=us-east-1

--- a/libs/nestjs/src/cli/cli-commands.spec.ts
+++ b/libs/nestjs/src/cli/cli-commands.spec.ts
@@ -136,4 +136,32 @@ describe('runCli commands', () => {
     expect(code).toBe(0);
     expect(out.join('')).toMatch(/enabled\s+no/);
   });
+
+  it('hash: prints an argon2id hash that verifies, with no admin request', async () => {
+    const code = await runCli(['hash', 'hunter2']);
+    expect(code).toBe(0);
+    expect(fetchMock).not.toHaveBeenCalled(); // offline — never contacts the admin API
+    const printed = out.join('').trim();
+    expect(printed).toMatch(/^\$argon2id\$/);
+    const argon2 = await import('argon2');
+    expect(await argon2.verify(printed, 'hunter2')).toBe(true);
+  });
+
+  it('hash: reads the password from $OPENBUCKET_PASSWORD when no positional is given', async () => {
+    process.env.OPENBUCKET_PASSWORD = 'from-env-pw';
+    try {
+      const code = await runCli(['hash']);
+      expect(code).toBe(0);
+      const argon2 = await import('argon2');
+      expect(await argon2.verify(out.join('').trim(), 'from-env-pw')).toBe(true);
+    } finally {
+      delete process.env.OPENBUCKET_PASSWORD;
+    }
+  });
+
+  it('hash: with no password and no TTY, fails with a usage exit (2)', async () => {
+    const code = await runCli(['hash']);
+    expect(code).toBe(2);
+    expect(err.join('')).toMatch(/OPENBUCKET_PASSWORD/);
+  });
 });

--- a/libs/nestjs/src/cli/commands/hash.ts
+++ b/libs/nestjs/src/cli/commands/hash.ts
@@ -1,0 +1,44 @@
+/**
+ * `openbucket hash [password]` — generate an argon2id hash for the admin
+ * password (the `ADMIN_PASSWORD_HASH` env var / `admin.passwordHash` option).
+ *
+ * A local, OFFLINE utility: it never contacts the admin API and needs no
+ * credentials, so it works straight from `npx @openbucket/nestjs hash` with no
+ * repository checkout — the missing on-ramp for embed users, who previously had
+ * no shipped way to mint the hash the module requires at boot.
+ *
+ * The password comes from the positional argument, else `$OPENBUCKET_PASSWORD`,
+ * else a non-echoing prompt — it is never echoed and never leaves the machine.
+ * Only the resulting hash is printed to stdout, so it composes:
+ *
+ *   ADMIN_PASSWORD_HASH="$(openbucket hash 'my-strong-password')"
+ *   npx @openbucket/nestjs hash            # then type it at the prompt
+ */
+
+import { CliError, EXIT } from '../errors';
+import { printLine } from '../output';
+import { promptPassword } from '../prompt';
+
+export async function runHash(
+  positionals: string[],
+  env: NodeJS.ProcessEnv,
+): Promise<number> {
+  // Precedence: positional arg → $OPENBUCKET_PASSWORD → interactive prompt.
+  // A `--flag` is deliberately unsupported so the prompt path keeps the secret
+  // out of shell history; a positional mirrors the legacy helper script and
+  // stays scriptable.
+  let password = positionals[0] ?? env.OPENBUCKET_PASSWORD;
+  if (password === undefined) {
+    password = await promptPassword('Password to hash: ');
+  }
+  if (!password) {
+    throw new CliError('empty password — nothing to hash', EXIT.USAGE);
+  }
+
+  // argon2 is a native module and a runtime dependency of the package; load it
+  // lazily so unrelated CLI commands don't pay its startup cost.
+  const argon2 = await import('argon2');
+  const hash = await argon2.hash(password, { type: argon2.argon2id });
+  printLine(hash);
+  return EXIT.SUCCESS;
+}

--- a/libs/nestjs/src/cli/index.ts
+++ b/libs/nestjs/src/cli/index.ts
@@ -16,6 +16,7 @@ import { OPENBUCKET_VERSION } from '../lib/version';
 import { parseCli, type ParsedFlags } from './args';
 import { runBackup } from './commands/backup';
 import { runBuckets } from './commands/buckets';
+import { runHash } from './commands/hash';
 import { runKeys } from './commands/keys';
 import { runReplication } from './commands/replication';
 import { resolveConfig } from './config';
@@ -37,6 +38,7 @@ Commands:
   backup create [--bucket <b>] [-o <file.zip>] [--force]
   backup restore -f <file.zip> [--bucket <b>] --yes
   replication status                      show replication status
+  hash [password]                         print an argon2id ADMIN_PASSWORD_HASH (offline; no login)
 
 Global options:
   --endpoint <url>   admin endpoint (env OPENBUCKET_ENDPOINT; default http://127.0.0.1:3900)
@@ -83,6 +85,19 @@ export async function runCli(argv: string[]): Promise<number> {
   if (flags.help || !command) {
     printLine(USAGE);
     return EXIT.SUCCESS;
+  }
+
+  // `hash` is a local, offline utility — no admin endpoint, no login. Handle it
+  // before resolveConfig (which resolves admin credentials) so it works with no
+  // configuration at all, e.g. `npx @openbucket/nestjs hash`.
+  if (command === 'hash') {
+    try {
+      return await runHash(positionals.slice(1), process.env);
+    } catch (err) {
+      const e = toCliError(err);
+      printNotice(e.toStderr());
+      return e.exitCode;
+    }
   }
 
   try {


### PR DESCRIPTION
Closes the onboarding blocker the DX audit found: the admin module needs an argon2id `ADMIN_PASSWORD_HASH` at boot, but **no shipped tool produced one** — `scripts/hash-password.mjs` needs a repo clone + `npm ci`, and the CLI had no `hash` command. So `npm install @openbucket/nestjs` embed users hit a dead end, and the "just Docker" quickstart wasn't runnable from a clean machine.

## Changes
- **`openbucket hash [password]`** — a local, **offline** command (no admin API, no login), so `npx @openbucket/nestjs hash` works with zero checkout. Password precedence: positional → `$OPENBUCKET_PASSWORD` → non-echoing prompt. Only the hash is printed, so it composes: `ADMIN_PASSWORD_HASH="$(openbucket hash 'pw')"`.
- **Tests** — hashes + verifies from a positional and from `$OPENBUCKET_PASSWORD`; usage-exit when no password and no TTY.
- **`.env.example`** — the placeholder `JWT_SECRET` / root secrets previously **passed validation and booted insecurely**; replaced with clearly-invalid `REPLACE_ME` tokens (app refuses to boot) + a reference to `openbucket hash`.

## Verification
- Full nestjs suite green (1,188 tests) incl. 3 new hash tests.
- Exercised as a real CLI: `openbucket hash 'pw'` prints a valid `$argon2id$…` hash that round-trips through `argon2.verify`; `$OPENBUCKET_PASSWORD` path confirmed.

## Deferred (follow-up, flagged for review)
A Docker `hash` subcommand and an `OPENBUCKET_DEV=1` auto-credentials dev-mode — the latter is a security-design decision I'd rather you weigh in on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)