### PR TITLE
docs: surface `openbucket hash` across docs + cross-link new pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ GitHub Container Registry on every release:
 
 ```bash
 # 1. Generate an argon2id hash for your admin password → ADMIN_PASSWORD_HASH
-node scripts/hash-password.mjs 'choose-a-strong-password'
+#    (no repo checkout needed)
+npx @openbucket/nestjs hash 'choose-a-strong-password'
+# …or, from a repo clone: node scripts/hash-password.mjs 'choose-a-strong-password'
 
 # 2. Copy the env template and fill in the secrets (incl. the hash above)
 cp .env.example .env
@@ -342,7 +344,7 @@ commented list. The essentials:
 | ------------------------ | -------- | ------------ | ------------------------------------------------------------ |
 | `DATA_DIR`               | ✅       | —            | Directory for the SQLite DB + blob payloads + `sse.key`.     |
 | `JWT_SECRET`             | ✅       | —            | ≥ 32 chars; signs admin JWTs.                                |
-| `ADMIN_PASSWORD_HASH`    | ✅       | —            | argon2id hash (`node scripts/hash-password.mjs <pw>`).       |
+| `ADMIN_PASSWORD_HASH`    | ✅       | —            | argon2id hash (`npx @openbucket/nestjs hash <pw>`).          |
 | `ROOT_ACCESS_KEY_ID`     | ✅       | —            | 16–32 uppercase alphanumerics.                               |
 | `ROOT_SECRET_ACCESS_KEY` | ✅       | —            | ≥ 32 chars.                                                  |
 | `PORT`                   |          | `9000`       | HTTP listen port.                                            |

--- a/apps/docs/docs/getting-started/quickstart-docker.md
+++ b/apps/docs/docs/getting-started/quickstart-docker.md
@@ -13,8 +13,9 @@ You'll boot a self-hosted, S3-compatible object store in a container, then put y
 Run these three commands from the repository root:
 
 ```bash
-# 1. Hash your admin password (argon2id). Copy the printed line.
-node scripts/hash-password.mjs 'choose-a-strong-password'
+# 1. Hash your admin password (argon2id) — no repo checkout needed. Copy the printed line.
+npx @openbucket/nestjs hash 'choose-a-strong-password'
+#    …or, from a repo clone: node scripts/hash-password.mjs 'choose-a-strong-password'
 
 # 2. Create your .env from the template, then paste the hash + fill the secrets.
 cp .env.example .env
@@ -26,7 +27,7 @@ docker compose up --build
 When the logs settle, OpenBucket is listening on **http://localhost:9000**. Open the admin console at **http://localhost:9000/admin** and sign in with `admin` and the password you just hashed.
 
 :::tip[What each command did]
-`hash-password.mjs` prints an argon2id hash to stdout — the app stores only the hash, never your plaintext password. `docker compose up` builds the image from the repo `Dockerfile` and mounts a named volume (`openbucket-data`) at `/data`, so your buckets and objects survive a restart.
+`openbucket hash` prints an argon2id hash to stdout — the app stores only the hash, never your plaintext password. `docker compose up` builds the image from the repo `Dockerfile` and mounts a named volume (`openbucket-data`) at `/data`, so your buckets and objects survive a restart.
 :::
 
 ## Fill in your .env

--- a/apps/docs/docs/getting-started/quickstart-embed.md
+++ b/apps/docs/docs/getting-started/quickstart-embed.md
@@ -46,7 +46,7 @@ export class AppModule {}
 Start your app and point any S3 client at `http://your-host:3000/storage` (path-style, root credentials). The admin console is at `http://your-host:3000/storage/admin`.
 
 :::tip[Generating the argon2id hash]
-`admin.passwordHash` is an argon2id hash, never a plaintext password. Generate one with the repo helper: `node scripts/hash-password.mjs 'your-admin-password'`. `jwtSecret` and `rootCredentials.secretAccessKey` must each be at least 32 chars, and `passwordHash` must be a real argon2id string — the module validates all of this at boot and throws if it's wrong.
+`admin.passwordHash` is an argon2id hash, never a plaintext password. Generate one with the CLI that ships in the package — no repo checkout needed: `npx @openbucket/nestjs hash 'your-admin-password'` (or `openbucket hash 'your-admin-password'` once the package is installed). From a repo clone you can also run `node scripts/hash-password.mjs 'your-admin-password'`. `jwtSecret` and `rootCredentials.secretAccessKey` must each be at least 32 chars, and `passwordHash` must be a real argon2id string — the module validates all of this at boot and throws if it's wrong.
 :::
 
 ## What mounts where

--- a/apps/docs/docs/guides/cli.md
+++ b/apps/docs/docs/guides/cli.md
@@ -110,6 +110,24 @@ openbucket replication status
 
 Shows enabled/disabled, the outbox depth (`pending` / `inflight` / `failed`), the oldest pending age, the last error message, and a per-bucket breakdown. It **always succeeds** — an unconfigured replication is `disabled`, not an error. No remote endpoint or credential is ever surfaced.
 
+## Hash an admin password (offline)
+
+Every command above talks to a running instance — except one. `openbucket hash`
+is a **local, offline helper** that mints the argon2id hash for
+`ADMIN_PASSWORD_HASH` (standalone) or `admin.passwordHash` (embedded). It needs
+**zero config**: no endpoint, no login, no credentials.
+
+```bash
+npx @openbucket/nestjs hash 'choose-a-strong-password'   # no repo checkout needed
+openbucket hash            # omit the arg to be prompted (no echo)
+```
+
+The password comes from the positional arg, `$OPENBUCKET_PASSWORD`, or a
+non-echoing prompt — never a flag — and only the hash is printed, so it drops
+straight into an env file: `ADMIN_PASSWORD_HASH="$(openbucket hash '<password>')"`.
+It's the on-ramp for embed users with no repository checkout; from a repo clone,
+`node scripts/hash-password.mjs '<password>'` does the same thing.
+
 ## Exit codes
 
 Scriptable and stable:

--- a/apps/docs/docs/guides/securing-openbucket.md
+++ b/apps/docs/docs/guides/securing-openbucket.md
@@ -47,9 +47,12 @@ encrypted sub-key secrets.
 ## 2. argon2id admin hash
 
 The admin password is stored only as an **argon2id** hash — never plaintext.
-Generate the hash and pass it as `ADMIN_PASSWORD_HASH`:
+Generate the hash and pass it as `ADMIN_PASSWORD_HASH`. The `hash` command ships
+in the package, so it works with no repo checkout:
 
 ```bash
+npx @openbucket/nestjs hash 'choose-a-strong-password'
+# …or, from a repo clone:
 node scripts/hash-password.mjs 'choose-a-strong-password'
 ```
 
@@ -158,7 +161,9 @@ list, and a manual "scrub now" trigger, with a corrupt-count badge in the sideba
 
 This checklist reflects OpenBucket's durability-and-hardening work (the EPIC-08
 posture): refuse-to-boot env validation, explicit-deny bucket policies, at-rest
-encryption of secrets, a restrictive CSP, and fail-closed authorization. It is a
+encryption of secrets, a restrictive CSP, and fail-closed authorization. For the
+findings and remediations behind it, see the
+[2026 security audit](../concepts/security-audit-2026.md). It is a
 solid baseline for a self-hosted store — not a substitute for your own threat
 model, network segmentation, and OS-level hardening of the data volume.
 

--- a/apps/docs/docs/intro.md
+++ b/apps/docs/docs/intro.md
@@ -27,6 +27,8 @@ It comes in two shapes from one codebase:
 :::tip[New here? Store your first file in 5 minutes.]
 The [**first upload**](./getting-started/first-upload.md) tutorial takes you from
 zero to "an uploaded file with a shareable URL" — the thing most apps actually need.
+Weighing it up first? [**Is OpenBucket for you?**](./is-openbucket-for-you.md) lays
+out where it fits and where it doesn't.
 :::
 
 ![The OpenBucket admin console — the dashboard, with buckets, usage, and health at a glance](/img/admin_dashboard.png)

--- a/apps/docs/docs/operations/deployment.md
+++ b/apps/docs/docs/operations/deployment.md
@@ -40,8 +40,9 @@ volumes:
 Generate the secrets, then start it:
 
 ```bash
-# 1. argon2id hash for the admin password
-node scripts/hash-password.mjs 'choose-a-strong-password'
+# 1. argon2id hash for the admin password — no repo checkout needed
+npx @openbucket/nestjs hash 'choose-a-strong-password'
+#    …or, from a repo clone: node scripts/hash-password.mjs 'choose-a-strong-password'
 
 # 2. fill in .env (see the required vars below), then:
 docker compose up -d
@@ -71,7 +72,7 @@ is missing or weak. The five required variables:
 | --- | --- |
 | `DATA_DIR` | Absolute path to the data volume (no trailing slash). Holds the SQLite DB, blobs, and `sse.key`. |
 | `JWT_SECRET` | ≥ 32 chars, high-entropy. Signs admin JWTs. `openssl rand -base64 48`. |
-| `ADMIN_PASSWORD_HASH` | argon2id hash — `node scripts/hash-password.mjs '<password>'`. |
+| `ADMIN_PASSWORD_HASH` | argon2id hash — `npx @openbucket/nestjs hash '<password>'` (no repo checkout needed), or `node scripts/hash-password.mjs '<password>'` from a repo clone. |
 | `ROOT_ACCESS_KEY_ID` | 16–32 uppercase alphanumerics. |
 | `ROOT_SECRET_ACCESS_KEY` | ≥ 32 chars, high-entropy. |
 

--- a/apps/docs/docs/reference/cli-reference.md
+++ b/apps/docs/docs/reference/cli-reference.md
@@ -9,7 +9,8 @@ sidebar_position: 4
 `openbucket` is a dependency-free command-line client over the admin JSON API:
 bucket and key management, backup/restore, and replication status. It ships in
 the `@openbucket/nestjs` package, credentials never touch `argv`, and every error
-path is redacted before it reaches stderr — safe to script.
+path is redacted before it reaches stderr — safe to script. The one exception is
+[`hash`](#hash), a purely **offline** helper that talks to no server at all.
 
 ```bash
 # List buckets on a running instance (log in with a prompted password):
@@ -101,6 +102,33 @@ issues **no request at all** — not even a login — unless you pass `--yes`.
 ```bash
 openbucket replication status --quiet   # prints "enabled" or "disabled"
 ```
+
+### `hash`
+
+| Command | Arguments | Description |
+| --- | --- | --- |
+| `hash` | `[password]` | Print an argon2id hash for `ADMIN_PASSWORD_HASH` / `admin.passwordHash`. **Offline** — issues no request. |
+
+```bash
+# No repo checkout needed — the command ships in @openbucket/nestjs:
+npx @openbucket/nestjs hash 'choose-a-strong-password'
+
+ADMIN_PASSWORD_HASH="$(openbucket hash 'choose-a-strong-password')"
+openbucket hash            # omit the arg to be prompted (no echo)
+```
+
+The password is read from the positional argument, else `$OPENBUCKET_PASSWORD`,
+else an interactive non-echoing prompt — **never** a flag, so it can't land on
+`argv`. Only the resulting hash is written to stdout.
+
+:::note[This command is offline — unlike every other one]
+`hash` needs **no `--endpoint`, no login, and no credentials**. It never contacts
+the admin API — it just computes a hash locally and prints it. That makes it the
+on-ramp for embed users who have no repository checkout: `npx @openbucket/nestjs
+hash '<password>'` mints the hash the module requires at boot, with nothing else
+installed. (From a repo clone, `node scripts/hash-password.mjs '<password>'` does
+the same thing.)
+:::
 
 ## Exit codes
 

--- a/apps/docs/docs/reference/configuration.md
+++ b/apps/docs/docs/reference/configuration.md
@@ -17,7 +17,8 @@ Grab the essentials and go:
 # The five required standalone settings:
 DATA_DIR=/data
 JWT_SECRET=$(openssl rand -base64 48)
-ADMIN_PASSWORD_HASH=$(node scripts/hash-password.mjs 'your-admin-password')
+ADMIN_PASSWORD_HASH=$(npx @openbucket/nestjs hash 'your-admin-password')  # no repo checkout needed
+# …or, from a repo clone: $(node scripts/hash-password.mjs 'your-admin-password')
 ROOT_ACCESS_KEY_ID=AKIAEXAMPLE000000000
 ROOT_SECRET_ACCESS_KEY=$(openssl rand -base64 48)
 ```
@@ -44,7 +45,7 @@ anything required is missing or malformed. Unknown variables are ignored.
 | --- | :-: | --- | --- |
 | `DATA_DIR` | ✅ | — | Directory for the SQLite metadata DB, blob payloads, and the generated `sse.key`. No trailing slash. |
 | `JWT_SECRET` | ✅ | — | Strong secret (≥ 32 chars). Signs admin JWTs. |
-| `ADMIN_PASSWORD_HASH` | ✅ | — | argon2id hash — generate with `node scripts/hash-password.mjs '<password>'`. |
+| `ADMIN_PASSWORD_HASH` | ✅ | — | argon2id hash — generate with `npx @openbucket/nestjs hash '<password>'` (no repo checkout needed), or `node scripts/hash-password.mjs '<password>'` from a repo clone. See the [`hash` command](./cli-reference.md#hash). |
 | `ROOT_ACCESS_KEY_ID` | ✅ | — | 16–32 uppercase alphanumerics (`^[A-Z0-9]{16,32}$`). |
 | `ROOT_SECRET_ACCESS_KEY` | ✅ | — | Strong secret (≥ 32 chars). The root SigV4 credential. |
 

--- a/apps/docs/docs/reference/s3-compatibility.md
+++ b/apps/docs/docs/reference/s3-compatibility.md
@@ -24,7 +24,8 @@ await s3.send(new PutObjectCommand({ Bucket: 'my-bucket', Key: 'a.jpg', Body: bu
 ```
 
 The wire surface is exercised by the [conformance suite](https://github.com/ProjectBay/openbucket/tree/main/apps/conformance)
-against the real `aws` CLI, MinIO's `mc`, and `s3cmd`.
+against the real `aws` CLI, MinIO's `mc`, and `s3cmd`. See how OpenBucket
+[compares to MinIO](../comparisons/vs-minio.md) if you're choosing between them.
 
 ## Supported operations
 

--- a/libs/nestjs/README.md
+++ b/libs/nestjs/README.md
@@ -1082,6 +1082,20 @@ openbucket backup restore -f snapshot.zip --yes           # RESETS the target �
 openbucket replication status
 ```
 
+One command is **offline** — `openbucket hash` mints the argon2id hash for
+`admin.passwordHash` (`ADMIN_PASSWORD_HASH` standalone). It contacts no server and
+needs no endpoint, login, or credentials, so it works straight from `npx` with no
+repository checkout — the on-ramp for embedding, where you must supply the hash the
+module validates at boot:
+
+```bash
+npx @openbucket/nestjs hash 'choose-a-strong-password'   # no repo checkout needed
+openbucket hash            # omit the arg to be prompted (no echo)
+```
+
+The password comes from the positional arg, `$OPENBUCKET_PASSWORD`, or a
+non-echoing prompt — never a flag — and only the hash is printed.
+
 **Security posture** (mirrors the server's): the password is read only from
 `$OPENBUCKET_PASSWORD` or an interactive non-echoing prompt — **never** from a
 flag (so it can't land on `argv`/`ps`); the bearer token lives in memory for the


### PR DESCRIPTION
## What & why

`openbucket hash [password]` (PR #46) is a new **offline** CLI utility that prints an argon2id hash for `ADMIN_PASSWORD_HASH` / `admin.passwordHash`. Because it ships in `@openbucket/nestjs`, `npx @openbucket/nestjs hash '<password>'` works with **no repository checkout** — the missing on-ramp for `npm install` embed users, who previously could only run `node scripts/hash-password.mjs` (needs a full repo clone + `npm ci`).

This PR surfaces it everywhere the repo-only script was the sole option, documents the command, and cross-links the four new docs pages.

## Changes

**A. `openbucket hash` as the primary hash-generation path** (repo script kept as the "from a repo clone" alternative):
- `README.md` — Docker quickstart step + `ADMIN_PASSWORD_HASH` config-table row
- `apps/docs/docs/getting-started/quickstart-docker.md`
- `apps/docs/docs/getting-started/quickstart-embed.md` — the argon2id tip block now **leads** with `npx @openbucket/nestjs hash` (embed users have no repo)
- `apps/docs/docs/reference/configuration.md`
- `apps/docs/docs/operations/deployment.md`
- `apps/docs/docs/guides/securing-openbucket.md`

**B. Document the `hash` command**
- `apps/docs/docs/reference/cli-reference.md` — new `### hash` section, explicitly calling out that it is OFFLINE (no `--endpoint`, no login, no credentials) unlike every other command
- `apps/docs/docs/guides/cli.md` — short "Hash an admin password (offline)" subsection (zero config)
- `libs/nestjs/README.md` — documents the offline `hash` command in the CLI section

**C. Cross-link the 4 new pages** (natural inbound links)
- `apps/docs/docs/intro.md` → `is-openbucket-for-you`
- `apps/docs/docs/guides/securing-openbucket.md` → `concepts/security-audit-2026`
- `apps/docs/docs/reference/s3-compatibility.md` → `comparisons/vs-minio`

## Verification

`cd apps/docs && npx docusaurus build` succeeds with **no new broken-link/anchor warnings** — only the pre-existing "Noncharacter in input stream" minifier warning on the persistence whitepaper page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)