### PR TITLE
feat(multer): ship OpenBucketFileInterceptor as a real export

### DIFF
--- a/apps/docs/blog/2026-07-08-nestjs-file-uploads-in-10-minutes.md
+++ b/apps/docs/blog/2026-07-08-nestjs-file-uploads-in-10-minutes.md
@@ -127,8 +127,8 @@ Add `BucketBootstrap` to your module's `providers`.
 
 ## Step 5 — The upload endpoint
 
-Here's the whole thing. `openBucketStorage` is a drop-in multer storage engine, so
-`FileInterceptor` streams the part **straight into the store** — no temp file. The
+Here's the whole thing. `OpenBucketFileInterceptor` streams the multipart part
+**straight into the store** — no temp file, no `file.buffer`. The
 `@UploadedToBucket()` decorator hands you the committed object, and
 `UploadValidationExceptionFilter` turns a rejected upload into a clean `HTTP 400`.
 
@@ -139,9 +139,8 @@ import {
   UseFilters,
   UseInterceptors,
 } from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
 import {
-  openBucketStorage,
+  OpenBucketFileInterceptor,
   UploadedToBucket,
   UploadValidationExceptionFilter,
   type UploadedFileInfo,
@@ -152,15 +151,13 @@ export class FilesController {
   @Post()
   @UseFilters(UploadValidationExceptionFilter) // rejected upload → HTTP 400
   @UseInterceptors(
-    FileInterceptor('file', {
-      storage: openBucketStorage({
-        bucket: 'uploads',
-        key: 'uuid', // generate a safe, unique key
-        validate: {
-          maxBytes: 10 * 1024 * 1024, // 10 MiB
-          allowedContentTypes: ['image/*'], // sniffed, not trusted from the client
-        },
-      }),
+    OpenBucketFileInterceptor('file', {
+      bucket: 'uploads',
+      key: 'uuid', // generate a safe, unique key
+      validate: {
+        maxBytes: 10 * 1024 * 1024, // 10 MiB
+        allowedContentTypes: ['image/*'], // sniffed, not trusted from the client
+      },
     }),
   )
   upload(@UploadedToBucket() file: UploadedFileInfo) {

--- a/apps/docs/docs/getting-started/first-upload.md
+++ b/apps/docs/docs/getting-started/first-upload.md
@@ -19,11 +19,11 @@ These three symbols ship behind the dedicated **`@openbucket/nestjs/multer`** su
 ```ts
 import { Controller, Post, UseFilters, UseInterceptors } from '@nestjs/common';
 import {
+  OpenBucketFileInterceptor,
   UploadedToBucket,
   UploadValidationExceptionFilter,
   type UploadedFileInfo,
 } from '@openbucket/nestjs/multer';
-import { OpenBucketFileInterceptor } from './open-bucket-file.interceptor'; // ← defined below
 
 @Controller('files')
 @UseFilters(UploadValidationExceptionFilter) // a rejected upload → HTTP 400
@@ -49,36 +49,14 @@ That's the whole upload path. Post a `multipart/form-data` request with a `file`
 The engine sniffs the type from the body's magic bytes and the **sniffed type wins** over whatever the client declared — so a "PNG" that's really HTML is caught and rejected, not stored. `file.contentType` is the resolved, verified type.
 :::
 
-### Wire up the DI-friendly interceptor
-
-The storage engine needs the `OpenBucketService` **instance**, but inside a class-property `@UseInterceptors(...)` decorator `this` isn't available yet. The fix is a tiny `mixin` interceptor that receives `ob` from the container and builds the engine at construction. Define it once and reuse it everywhere:
-
-```ts
-// open-bucket-file.interceptor.ts
-import { Injectable, mixin, type NestInterceptor, type Type } from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
-import { OpenBucketService } from '@openbucket/nestjs';
-import { openBucketStorage, type OpenBucketStorageOptions } from '@openbucket/nestjs/multer';
-
-/** A `FileInterceptor` whose storage is a DI-resolved OpenBucket engine. */
-export function OpenBucketFileInterceptor(
-  field: string,
-  opts: OpenBucketStorageOptions,
-): Type<NestInterceptor> {
-  @Injectable()
-  class OpenBucketInterceptor implements NestInterceptor {
-    private readonly delegate: NestInterceptor;
-    constructor(ob: OpenBucketService) {
-      const Base = FileInterceptor(field, { storage: openBucketStorage(ob, opts) });
-      this.delegate = new Base();
-    }
-    intercept(...args: Parameters<NestInterceptor['intercept']>) {
-      return this.delegate.intercept(...args);
-    }
-  }
-  return mixin(OpenBucketInterceptor);
-}
-```
+:::note[`OpenBucketFileInterceptor` is provided for you]
+Under the hood, the storage engine needs the `OpenBucketService` instance — which
+isn't available inside a class-property `@UseInterceptors(...)` decorator.
+`OpenBucketFileInterceptor` is the DI-friendly wrapper that resolves the service
+from the container for you, so you just import it from `@openbucket/nestjs/multer`
+— no boilerplate to copy. (Prefer to wire the raw engine yourself? Use
+`openBucketStorage(ob, opts)` with a `FileInterceptor` inside a custom mixin.)
+:::
 
 ## Make sure the bucket exists
 

--- a/apps/docs/docs/guides/file-uploads.md
+++ b/apps/docs/docs/guides/file-uploads.md
@@ -147,8 +147,8 @@ import {
   UploadedToBucket,
   UploadValidationExceptionFilter,
   type UploadedFileInfo,
+  OpenBucketFileInterceptor,
 } from '@openbucket/nestjs/multer';
-import { OpenBucketFileInterceptor } from './open-bucket-file.interceptor'; // see below
 
 @Controller('files')
 @UseFilters(UploadValidationExceptionFilter) // maps a rejected upload → HTTP 400
@@ -171,34 +171,20 @@ export class FilesController {
 
 `UploadValidationExceptionFilter` renders a rejected upload as a stable `{ statusCode: 400, error: 'Bad Request', code, message }` body instead of an opaque 500. It is scoped by `@Catch(UploadValidationError)`, so an S3 error like `NoSuchBucketError` is **not** swallowed — make sure the bucket exists first.
 
-### The `this.ob` wiring helper
+### How `OpenBucketFileInterceptor` works (and the lower-level engine)
 
-`openBucketStorage` needs the `OpenBucketService` instance, but inside a class-property `@UseInterceptors(...)` decorator `this` is not available. The DI-friendly fix is a one-time mixin interceptor that receives `ob` from the container:
+`OpenBucketFileInterceptor` exists because `openBucketStorage` needs the
+`OpenBucketService` instance, which isn't available inside a class-property
+`@UseInterceptors(...)` decorator. It's a `mixin` interceptor whose constructor
+receives `OpenBucketService` from the container and builds the storage engine — so
+you import it and move on, no boilerplate.
+
+If you'd rather assemble it yourself (e.g. to add multer `limits`), the raw engine
+is exported too — wire `openBucketStorage(ob, opts)` into your own `FileInterceptor`
+mixin:
 
 ```ts
-// open-bucket-file.interceptor.ts
-import { Injectable, mixin, type NestInterceptor, type Type } from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
-import { OpenBucketService } from '@openbucket/nestjs';
-import { openBucketStorage, type OpenBucketStorageOptions } from '@openbucket/nestjs/multer';
-
-export function OpenBucketFileInterceptor(
-  field: string,
-  opts: OpenBucketStorageOptions,
-): Type<NestInterceptor> {
-  @Injectable()
-  class OpenBucketInterceptor implements NestInterceptor {
-    private readonly delegate: NestInterceptor;
-    constructor(ob: OpenBucketService) {
-      const Base = FileInterceptor(field, { storage: openBucketStorage(ob, opts) });
-      this.delegate = new Base();
-    }
-    intercept(...args: Parameters<NestInterceptor['intercept']>) {
-      return this.delegate.intercept(...args);
-    }
-  }
-  return mixin(OpenBucketInterceptor);
-}
+const Base = FileInterceptor(field, { storage: openBucketStorage(ob, opts) });
 ```
 
 The engine's `bucket`, `key`, and `validate` options can each be a static value or a `(req, file) => …` function, so you can derive the bucket or key per request. If a later part of the request fails, multer calls the engine's rollback, which deletes the already-committed object.

--- a/libs/nestjs/README.md
+++ b/libs/nestjs/README.md
@@ -668,11 +668,11 @@ that never import this subpath never pull it in):
 ```ts
 import { Controller, Post, UseFilters, UseInterceptors } from '@nestjs/common';
 import {
+  OpenBucketFileInterceptor,
   UploadedToBucket,
   UploadValidationExceptionFilter,
   type UploadedFileInfo,
 } from '@openbucket/nestjs/multer';
-import { OpenBucketFileInterceptor } from './open-bucket-file.interceptor'; // ← below
 
 @Controller('files')
 @UseFilters(UploadValidationExceptionFilter) // maps a rejected upload → HTTP 400
@@ -692,43 +692,14 @@ export class FilesController {
 }
 ```
 
-**The `this.ob` caveat.** `openBucketStorage` needs the `OpenBucketService`
-_instance_, but inside a class-property `@UseInterceptors(...)` decorator `this`
-is not available at decoration time. The DI-friendly fix is a tiny `mixin`
-interceptor that receives `ob` from the container and builds the storage engine at
-construction — define it once and reuse it everywhere:
-
-```ts
-// open-bucket-file.interceptor.ts
-import {
-  Injectable,
-  mixin,
-  type NestInterceptor,
-  type Type,
-} from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
-import { OpenBucketService } from '@openbucket/nestjs';
-import { openBucketStorage, type OpenBucketStorageOptions } from '@openbucket/nestjs/multer';
-
-/** A `FileInterceptor` whose storage is a DI-resolved OpenBucket engine. */
-export function OpenBucketFileInterceptor(
-  field: string,
-  opts: OpenBucketStorageOptions,
-): Type<NestInterceptor> {
-  @Injectable()
-  class OpenBucketInterceptor implements NestInterceptor {
-    private readonly delegate: NestInterceptor;
-    constructor(ob: OpenBucketService) {
-      const Base = FileInterceptor(field, { storage: openBucketStorage(ob, opts) });
-      this.delegate = new Base();
-    }
-    intercept(...args: Parameters<NestInterceptor['intercept']>) {
-      return this.delegate.intercept(...args);
-    }
-  }
-  return mixin(OpenBucketInterceptor);
-}
-```
+**How `OpenBucketFileInterceptor` resolves the service.** `openBucketStorage`
+needs the `OpenBucketService` _instance_, but inside a class-property
+`@UseInterceptors(...)` decorator `this` is not available at decoration time.
+`OpenBucketFileInterceptor` handles that for you: it's a `mixin` interceptor whose
+constructor receives `OpenBucketService` from the container and builds the storage
+engine — so you just import it, no boilerplate. If you'd rather compose it
+yourself, `openBucketStorage(ob, opts)` is exported too for use inside your own
+`FileInterceptor` mixin.
 
 Notes:
 

--- a/libs/nestjs/src/lib/adapters/multer/index.ts
+++ b/libs/nestjs/src/lib/adapters/multer/index.ts
@@ -15,6 +15,8 @@ export {
   type PerRequestKeyFn,
 } from './open-bucket-storage';
 
+export { OpenBucketFileInterceptor } from './open-bucket-file.interceptor';
+
 export {
   UploadedToBucket,
   uploadedToBucketFactory,

--- a/libs/nestjs/src/lib/adapters/multer/open-bucket-file.interceptor.spec.ts
+++ b/libs/nestjs/src/lib/adapters/multer/open-bucket-file.interceptor.spec.ts
@@ -1,0 +1,43 @@
+import type { CallHandler, ExecutionContext } from '@nestjs/common';
+
+import type { OpenBucketService } from '../../open-bucket.service';
+import { OpenBucketFileInterceptor } from './open-bucket-file.interceptor';
+
+/** A minimal fake service — the interceptor only needs it to build the engine. */
+const fakeOb = {
+  uploadFrom: jest.fn(),
+  deleteObject: jest.fn(),
+} as unknown as OpenBucketService;
+
+describe('OpenBucketFileInterceptor', () => {
+  it('returns an injectable interceptor mixin (a class)', () => {
+    const Interceptor = OpenBucketFileInterceptor('file', { bucket: 'uploads' });
+    expect(typeof Interceptor).toBe('function');
+  });
+
+  it('constructs with the injected OpenBucketService and exposes intercept()', () => {
+    const Interceptor = OpenBucketFileInterceptor('file', {
+      bucket: 'uploads',
+      key: 'uuid',
+    });
+    const instance = new Interceptor(fakeOb);
+    expect(typeof instance.intercept).toBe('function');
+  });
+
+  it('delegates intercept() to the underlying FileInterceptor', () => {
+    const Interceptor = OpenBucketFileInterceptor('file', { bucket: 'uploads' });
+    const instance = new Interceptor(fakeOb) as InstanceType<typeof Interceptor> & {
+      delegate: { intercept: jest.Mock };
+    };
+    const spy = jest
+      .spyOn(instance.delegate, 'intercept')
+      .mockReturnValue('DELEGATED' as never);
+    const ctx = {} as ExecutionContext;
+    const next = { handle: jest.fn() } as unknown as CallHandler;
+
+    const result = instance.intercept(ctx, next);
+
+    expect(spy).toHaveBeenCalledWith(ctx, next);
+    expect(result).toBe('DELEGATED');
+  });
+});

--- a/libs/nestjs/src/lib/adapters/multer/open-bucket-file.interceptor.ts
+++ b/libs/nestjs/src/lib/adapters/multer/open-bucket-file.interceptor.ts
@@ -1,0 +1,68 @@
+/**
+ * `OpenBucketFileInterceptor(field, opts)` — the one-line upload interceptor.
+ *
+ * `openBucketStorage` needs the `OpenBucketService` instance, but inside a
+ * class-property `@UseInterceptors(...)` decorator `this` is not available. This
+ * is the DI-friendly fix: a `mixin` interceptor whose constructor receives
+ * `OpenBucketService` from the Nest container, wires it into a `FileInterceptor`,
+ * and delegates. Drop it straight into a handler:
+ *
+ *   @Post()
+ *   @UseFilters(UploadValidationExceptionFilter)
+ *   @UseInterceptors(
+ *     OpenBucketFileInterceptor('file', {
+ *       bucket: 'uploads',
+ *       key: 'uuid',
+ *       validate: { maxBytes: 10 * 1024 * 1024, allowedContentTypes: ['image/*'] },
+ *     }),
+ *   )
+ *   upload(@UploadedToBucket() file: UploadedFileInfo) { … }
+ *
+ * `bucket` / `key` / `validate` may each be a static value or a
+ * `(req, file) => …` function, so the destination is derivable per request.
+ */
+
+import {
+  Injectable,
+  mixin,
+  type NestInterceptor,
+  type Type,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+
+import { OpenBucketService } from '../../open-bucket.service';
+
+import {
+  openBucketStorage,
+  type OpenBucketStorageOptions,
+} from './open-bucket-storage';
+
+/**
+ * Build a request-scoped file interceptor that streams the named multipart part
+ * straight into OpenBucket. Returns a `mixin` class so Nest injects
+ * {@link OpenBucketService} for you — no `this.ob` wiring in your controller.
+ */
+export function OpenBucketFileInterceptor(
+  field: string,
+  opts: OpenBucketStorageOptions,
+): Type<NestInterceptor> {
+  @Injectable()
+  class OpenBucketInterceptor implements NestInterceptor {
+    private readonly delegate: NestInterceptor;
+
+    constructor(ob: OpenBucketService) {
+      const Base = FileInterceptor(field, {
+        storage: openBucketStorage(ob, opts),
+      });
+      this.delegate = new Base();
+    }
+
+    intercept(
+      ...args: Parameters<NestInterceptor['intercept']>
+    ): ReturnType<NestInterceptor['intercept']> {
+      return this.delegate.intercept(...args);
+    }
+  }
+
+  return mixin(OpenBucketInterceptor);
+}


### PR DESCRIPTION
Fixes the bug found while writing the blog tutorial: the flagship one-line upload recipe used `OpenBucketFileInterceptor`, **but it was never exported** — every doc defined the same DI mixin by hand, and a copy-paste of the recipe wouldn't compile. You chose to implement the wrapper; here it is.

## Changes
- **New export** `OpenBucketFileInterceptor(field, opts)` in `@openbucket/nestjs/multer` — a `mixin` interceptor whose constructor receives `OpenBucketService` from the container and wires `FileInterceptor` + `openBucketStorage(ob, opts)`. This is the exact DI pattern the docs previously asked users to copy, now shipped.
- **Unit tests** — mixin shape + `intercept()` delegation.
- **Docs** — replaced the hand-rolled mixin definitions in `libs/nestjs/README.md`, `getting-started/first-upload.md`, and `guides/file-uploads.md` with a plain import from the package (the raw `openBucketStorage(ob, opts)` is still exported + documented for custom wiring).
- **Blog tutorial fixed** — it was calling `openBucketStorage({...})` without the required service instance (wouldn't compile); now uses the new interceptor.

## Verification
- `nx build nestjs` compiles clean (real tsc build).
- Full nestjs suite green (incl. the new interceptor spec).
- `docusaurus build` passes; no stale `./open-bucket-file.interceptor` imports remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)