### PR TITLE
release polish: fix vv release-title bug + bump doc version refs to alpha.18

### DIFF
--- a/.github/workflows/release-nestjs.yml
+++ b/.github/workflows/release-nestjs.yml
@@ -118,7 +118,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Strip either tag prefix (`nestjs-v*` or the dual-release `v*`) so the
+          # title reads `v0.1.0-…` (not `vv0.1.0-…`) and the CHANGELOG lookup below
+          # matches `## [0.1.0-…]`. Mirrors the version-verify step above.
           version="${GITHUB_REF_NAME#nestjs-v}"
+          version="${version#v}"
           notes="$(awk -v v="$version" '
             $0 ~ "^## \\[" v "\\]" { grab=1; next }
             grab && /^## \[/ { exit }

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ collide with a host app's database, mounts everything under a configurable
 GitHub Container Registry on every release:
 
 - **Image:** `ghcr.io/projectbay/openbucket`
-- **Tags:** `X.Y.Z` — one immutable tag per release (e.g. `0.1.0-alpha.17`) ·
+- **Tags:** `X.Y.Z` — one immutable tag per release (e.g. `0.1.0-alpha.18`) ·
   `sha-<commit>` — an exact build · `latest` — stable (non-prerelease) releases
   only, so none yet while pre-1.0 · `edge` — manual builds
 - **📦 Browse all published versions →**
@@ -154,7 +154,7 @@ cp .env.example .env
 
 # 3. Run a published image (pick a tag from the versions page above)
 docker run --rm -p 9000:9000 --env-file .env -v openbucket-data:/data \
-  ghcr.io/projectbay/openbucket:0.1.0-alpha.17
+  ghcr.io/projectbay/openbucket:0.1.0-alpha.18
 ```
 
 Prefer to **build from source**? The bundled compose file does that instead:

--- a/apps/docs/docs/operations/upgrading.md
+++ b/apps/docs/docs/operations/upgrading.md
@@ -111,7 +111,7 @@ npm install @openbucket/nestjs
 npm install @openbucket/nestjs@next
 
 # A specific version (recommended for reproducible deploys):
-npm install @openbucket/nestjs@0.1.0-alpha.14
+npm install @openbucket/nestjs@0.1.0-alpha.18
 ```
 
 Migrations still run automatically when your host app boots (`OpenBucketModule`


### PR DESCRIPTION
Two release follow-ups:

1. **Fix the `vv0.1.0-…` GitHub Release title + missing notes.** The dual-release `v*` tags (alpha.16/17/18) produced releases titled `vv0.1.0-…` with placeholder bodies instead of the CHANGELOG section — the *Create GitHub Release* step stripped only `nestjs-v`, not the plain `v`, so the CHANGELOG lookup (`## [v0.1.0-…]`) never matched. Now double-strips like the version-verify step. (I already corrected the live v0.1.0-alpha.18 release by hand.)
2. **Bump pinned version examples to `0.1.0-alpha.18`** in the docs: the Docker example tag + `docker run` pin in README, and the "specific version" npm example in the upgrading guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)