### PR TITLE
docs(pm): Road to 1.0 epic + expanded public 1.0 bar

### DIFF
--- a/apps/docs/docs/roadmap.md
+++ b/apps/docs/docs/roadmap.md
@@ -43,12 +43,23 @@ edges:
 
 ## The 1.0 bar
 
-We consider OpenBucket 1.0 when:
+1.0 is a promise: **the API is stable to build on, and your data is safe.** We tag
+it when:
 
-- The public library + admin API surfaces are frozen under semver.
-- The S3 compatibility matrix is backed by a machine-generated, dated conformance
-  report.
-- A stable release sits on the npm `latest` tag (not a pre-release).
+- **Stability** — the public library surface (`OpenBucketService`, module options,
+  the multer adapter) and the admin API are reviewed and **frozen under a written
+  semver / deprecation policy** — after real-world usage has had a chance to shake
+  out the rough edges.
+- **Correctness** — the release gate runs the **full** test suite (no skipped
+  specs), and the S3 compatibility matrix is backed by a **machine-generated, dated
+  conformance report** (client × operation), not a hand-kept table.
+- **Data safety** — a tested **backup → upgrade → restore** path, a stable on-disk
+  format, and a disaster-recovery runbook.
+- **Trust** — a security re-pass of everything added since the
+  [2026 audit](./concepts/security-audit-2026.md) (replication, tiering, scoped
+  keys), a published threat model, and honest single-node benchmarks.
+- **Release** — a stable (non-prerelease) version on the npm `latest` tag and the
+  `:latest` image.
 
 ## What OpenBucket is deliberately _not_ doing
 

--- a/docs/pm/epics/EPIC-14-road-to-1.0.md
+++ b/docs/pm/epics/EPIC-14-road-to-1.0.md
@@ -1,0 +1,86 @@
+---
+id: EPIC-14
+title: Road to 1.0 (release readiness)
+status: ready
+whitepaper_section: "cross-cutting"
+owner_area: backend
+---
+
+## Objective
+
+Earn the right to tag `v1.0.0`. A 1.0 of a data store makes two promises to the
+world: **(1) the public API is stable enough to build on** (semver from here), and
+**(2) your data is safe with us**. The feature surface is already complete and
+tested; what's missing before 1.0 is the *evidence* for promise (2) and the
+*deliberate commitment* of promise (1). This Epic is the checklist that closes that
+gap. It is explicitly gated on some real-world usage (see Sequencing): freezing an
+API that no one has run in anger is the classic premature-1.0 mistake.
+
+## The 1.0 exit bar (definition of done)
+
+1. The public library surface (`OpenBucketService`, `OpenBucketModule` options, the
+   `/multer` adapter) and the admin JSON API are **reviewed and frozen** under a
+   written semver / deprecation policy.
+2. The **release gate runs the full unit suite** (no skipped-because-flaky specs)
+   and a **coverage threshold** is enforced.
+3. The S3 compatibility matrix is backed by a **machine-generated, dated conformance
+   report** (client × operation, image sha), not a hand-maintained table.
+4. A **tested backup → upgrade → restore drill** exists and the on-disk format is
+   declared stable; a disaster-recovery runbook is published.
+5. The **new surface added since the July 2026 audit** (replication, tiering, scoped
+   keys, `ADMIN_PASSWORD`) has had a focused security re-pass; the threat model
+   (STRIDE) is published.
+6. **Honest single-node benchmarks** and a **production checklist** are published.
+7. A stable (non-prerelease) version sits on the npm `latest` tag and the
+   `ghcr.io`/`docker.io` `latest` image tag.
+
+## Scope — workstreams
+
+### A. API stability (the defining work)
+- **API-review pass** of every package export (`libs/nestjs/src/index.ts`, the
+  `/multer` subpath), the module options (`open-bucket-options.ts`), and the service
+  facade (`open-bucket.service.ts`). Settle naming, defaults, and types that would
+  be painful to change post-freeze. (Recent churn to watch: `admin.passwordHash` →
+  optional + `admin.password`.)
+- **Admin API review** — endpoint/DTO shapes + the generated `libs/api-client`.
+- Write an **API-stability & deprecation policy** doc (what semver covers).
+
+### B. Provable correctness
+- **De-flake the concurrency / blob-store specs** so `release-nestjs.yml` can stop
+  skipping the unit suite. The release you tag 1.0 must pass its own full suite.
+- **Machine-generated, dated conformance report** from `apps/conformance/` (feeds
+  `reference/s3-compatibility.md`).
+- **Coverage gate** — surface + enforce the number (CI already runs `--coverage`).
+
+### C. Data-safety proof
+- **Backup → upgrade → restore drill** as an automated test over a populated DB;
+  assert forward-only migrations round-trip.
+- Declare the **on-disk format stable**; document any format-version marker.
+- **Disaster-recovery runbook** (restore-to-roll-back is the model).
+
+### D. Security re-pass
+- Focused audit of the surface added since EPIC-08: async replication + tiering
+  (SSRF/credential handling), scoped-key policy evaluation, the new `ADMIN_PASSWORD`
+  seed path, presigned POST.
+- Publish the **threat model / STRIDE** doc (deferred from EPIC-08 as a spike).
+
+### E. Honest expectations
+- **Benchmarks**: single-node PUT/GET throughput at a few object sizes, stated
+  hardware + methodology. Answers "is one node fast enough?".
+- **Production checklist** doc (TLS proxy, backups on, replica configured, resource
+  limits). Complements the existing "Is OpenBucket for you?" page.
+
+### Out of scope (post-1.0)
+- Multi-node / clustering / HA — explicitly *not* a 1.0 goal (single-node by design).
+- New auth mechanisms (OIDC, full IAM policy language).
+
+## Sequencing / dependencies
+
+- **Launch + gather real usage runs in parallel and gates workstream A.** Do not
+  freeze the API (the irreversible step) until a handful of real deployments have
+  exercised it — real usage is the only reliable source of "we'd regret this shape".
+- B (correctness) and C (durability) can proceed immediately and independently.
+- D (security re-pass) should follow A/C so it audits the frozen surface.
+- E (benchmarks/checklist) is independent; do it whenever.
+- The final step is purely mechanical: cut a non-prerelease tag → the existing
+  release workflows promote `latest` on npm + the registries automatically.


### PR DESCRIPTION
Frames the pre-1.0 work as earning two promises — **a stable API** and **data safety** — not a feature count.

- **`docs/pm/epics/EPIC-14-road-to-1.0.md`** — the release-readiness checklist as workstreams: API stability (review + freeze + semver policy), provable correctness (de-flake the release gate, machine-generated conformance report, coverage gate), data-safety proof (backup→upgrade→restore drill, on-disk format stability, DR runbook), a security re-pass of the surface added since the July audit + a published threat model, and honest benchmarks + a production checklist. Includes sequencing — **real usage gates the API freeze** (don't freeze what nobody's run).
- **`roadmap.md`** — the public "1.0 bar" section expanded from 3 bullets to the honest five-part bar.

Related work (separate PRs, in flight): the API-review findings, the de-flaked specs, and the conformance report generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)