### PR TITLE
fix(admin): make admin.password work in library mode (+ harden two defaults)

### DIFF
--- a/libs/nestjs/src/lib/open-bucket-options.spec.ts
+++ b/libs/nestjs/src/lib/open-bucket-options.spec.ts
@@ -14,6 +14,10 @@ describe('resolveOptions', () => {
     expect(r.admin).toBeUndefined();
   });
 
+  it('defaults maxObjectSizeMb to 5 GiB (matches the env schema, not the old 5 TiB footgun) (MF-3)', () => {
+    expect(resolveOptions(base).limits.maxObjectSizeMb).toBe(5_120);
+  });
+
   it('defaults admin.serveUi to true when admin is provided', () => {
     const r = resolveOptions({ ...base, admin: { username: 'a', passwordHash: 'h', jwtSecret: 'j' } });
     expect(r.admin?.serveUi).toBe(true);
@@ -62,6 +66,22 @@ describe('validateSecurityCriticalOptions', () => {
 
   it('passes on well-formed secrets (with admin)', () => {
     expect(() => validate(validBase)).not.toThrow();
+  });
+
+  it('accepts a password-only admin block (no hash) — the admin.password path (MF-1)', () => {
+    const { admin, ...rest } = validBase;
+    void admin;
+    expect(() =>
+      validate({ ...rest, admin: { username: 'admin', password: 'a-strong-admin-pw', jwtSecret: SECRET } }),
+    ).not.toThrow();
+  });
+
+  it('rejects a too-short admin.password (MF-2)', () => {
+    const { admin, ...rest } = validBase;
+    void admin;
+    expect(() =>
+      validate({ ...rest, admin: { username: 'admin', password: 'short', jwtSecret: SECRET } }),
+    ).toThrow(/password/);
   });
 
   it('passes on a headless store (no admin) with a valid secret key', () => {

--- a/libs/nestjs/src/lib/open-bucket-options.ts
+++ b/libs/nestjs/src/lib/open-bucket-options.ts
@@ -315,7 +315,10 @@ export function resolveOptions(o: OpenBucketModuleOptions): ResolvedOpenBucketOp
         }
       : undefined,
     limits: {
-      maxObjectSizeMb: o.limits?.maxObjectSizeMb ?? 5_120_000,
+      // Default 5 GiB — matches the standalone env default (MAX_OBJECT_SIZE_MB).
+      // The former 5 TiB default was an unbounded-allocation footgun (CWE-770);
+      // an embedder raises it explicitly if they really need larger objects.
+      maxObjectSizeMb: o.limits?.maxObjectSizeMb ?? 5_120,
       maxMultipartParts: o.limits?.maxMultipartParts ?? 10_000,
       multipartTtlHours: o.limits?.multipartTtlHours ?? 24,
     },
@@ -387,9 +390,22 @@ export function validateSecurityCriticalOptions(o: ResolvedOpenBucketOptions): v
     admin: z
       .object({
         jwtSecret: strongSecret('admin.jwtSecret'),
+        // Either an argon2id hash OR a plaintext password (hashed at boot) — the
+        // refine below requires at least one, mirroring resolveOptions + the env
+        // schema. Without making `passwordHash` optional here, a `password`-only
+        // admin block (a supported config) would throw at boot.
         passwordHash: z
           .string()
-          .regex(/^\$argon2id\$/, 'admin.passwordHash must be an argon2id hash'),
+          .regex(/^\$argon2id\$/, 'admin.passwordHash must be an argon2id hash')
+          .optional(),
+        password: z
+          .string()
+          .min(8, 'admin.password must be at least 8 characters')
+          .optional(),
+      })
+      .refine((a) => !!a.passwordHash || !!a.password, {
+        message: 'admin requires either `passwordHash` (argon2id) or `password` (>= 8 chars)',
+        path: ['passwordHash'],
       })
       .optional(),
     // When a webhook URL is configured, the HMAC secret must be strong and the


### PR DESCRIPTION
The **pre-1.0 API review** caught a real bug in the `admin.password` feature from #55: it was **dead-on-arrival for embedders**. `resolveOptions` accepted a password-only admin block, but the *separate* `validateSecurityCriticalOptions` still required `admin.passwordHash`, so `forRoot({ admin: { password, jwtSecret } })` **threw at boot**. My #55 test only covered `resolveOptions`, so CI stayed green. (The standalone `ADMIN_PASSWORD` env path was unaffected — different validator.)

- **MF-1** — `validateSecurityCriticalOptions`: `passwordHash` optional + a `.refine` requiring `passwordHash` OR `password` (fail-closed, mirrors `resolveOptions` and the env schema).
- **MF-2** — enforce `admin.password` **min-length 8** in library mode, matching the env `ADMIN_PASSWORD` floor.
- **MF-3** — lower the library `maxObjectSizeMb` default **5 TiB → 5 GiB** to match the hardened env default (5 TiB was the CWE-770 footgun the env side already removed).

Tests: password-only admin now passes end-to-end (`resolveOptions` + `validateSecurityCriticalOptions`), too-short password rejected, 5 GiB default asserted. Full suite green (**1,200**), `nx build nestjs` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)