### PR TITLE
refactor(api): 1.0 freeze-prep — /standalone subpath, unify upload types, API polish

### DIFF
--- a/apps/openbucket-backend/src/main.ts
+++ b/apps/openbucket-backend/src/main.ts
@@ -19,7 +19,7 @@ import {
   OPEN_BUCKET_ORM_CONTEXT,
   normalizeMount,
   rewriteBaseHref,
-} from '@openbucket/nestjs';
+} from '@openbucket/nestjs/standalone';
 import { configureBodyParsers } from './bootstrap/body-parser';
 
 async function bootstrap(): Promise<void> {

--- a/apps/openbucket-backend/src/openapi-export.ts
+++ b/apps/openbucket-backend/src/openapi-export.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import { AdminModule, HealthModule, OpenBucketCoreModule } from '@openbucket/nestjs';
+import { AdminModule, HealthModule, OpenBucketCoreModule } from '@openbucket/nestjs/standalone';
 import { cleanupOpenApiDoc } from 'nestjs-zod';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';

--- a/libs/nestjs/package.json
+++ b/libs/nestjs/package.json
@@ -20,6 +20,10 @@
       "types": "./src/lib/adapters/multer/index.d.ts",
       "default": "./src/lib/adapters/multer/index.js"
     },
+    "./standalone": {
+      "types": "./src/standalone.d.ts",
+      "default": "./src/standalone.js"
+    },
     "./package.json": "./package.json"
   },
   "files": ["src", "assets", "README.md"],

--- a/libs/nestjs/src/index.ts
+++ b/libs/nestjs/src/index.ts
@@ -3,6 +3,7 @@ export {
   OPEN_BUCKET_OPTIONS,
   type OpenBucketModuleOptions,
   type OpenBucketModuleAsyncOptions,
+  type OpenBucketOptionsFactory,
   type ResolvedOpenBucketOptions,
 } from './lib/open-bucket-options';
 
@@ -15,15 +16,19 @@ export {
   type ObjectListResult,
   type ObjectInfo,
   type BucketInfo,
+  type CreateBucketOptions,
+  type PutObjectOptions,
+  type ListObjectsOptions,
   type PresignOptions,
   type PresignPostOptions,
   type PresignedPost,
   type MulterFileLike,
   type UploadSource,
   type UploadOptions,
+  type UploadedObject,
   type UploadResult,
+  type PostPolicyCondition,
 } from './lib/open-bucket.service';
-export { type PostPolicyCondition } from './lib/s3/sigv4/presigned-post';
 
 // Upload DX helpers (STORY-0803): validation model + sanitized key strategies +
 // the typed validation error hosts map to a 400.
@@ -38,23 +43,12 @@ export {
 } from './lib/open-bucket-upload';
 export { type ImageInfo } from './lib/storage/image-info';
 
-// The composition root (env-driven in phase 0b; phase 1 wires it to options).
-// Exported so the thin standalone app + the openapi-export tooling can bootstrap it.
-export { OpenBucketCoreModule } from './lib/open-bucket-core.module';
-export { AdminModule } from './lib/admin/admin.module';
-export { HealthModule } from './lib/admin/health/health.module';
-
-// Standalone `MOUNT_PATH` support: the wrapper root module that mounts the whole
-// tree under a subpath, plus the two pure helpers `main.ts` needs to be
-// mount-aware without duplicating logic — `normalizeMount` (the same
-// normalization the env schema + `forRoot` apply) and `rewriteBaseHref` (the SPA
-// `<base href>` rewrite the embedded SpaController uses).
-export { OpenBucketStandaloneModule } from './lib/open-bucket-standalone.module';
-export { normalizeMount } from './lib/open-bucket-options';
-export { rewriteBaseHref } from './lib/spa/spa-utils';
-
-// Config service consumed by the standalone app's main.ts (phase 0b).
-export { AppConfigService } from './lib/common/config/app-config.service';
+// NOTE: the composition-root internals the first-party standalone backend needs
+// to bootstrap OpenBucket from the published package — `OpenBucketCoreModule`,
+// `OpenBucketStandaloneModule`, `AdminModule`, `HealthModule`, `AppConfigService`,
+// `normalizeMount`, `rewriteBaseHref`, and `OPEN_BUCKET_ORM_CONTEXT` — are NOT
+// host-app API and are intentionally NOT exported here. Import them from the
+// `@openbucket/nestjs/standalone` SUBPATH instead (see `standalone.ts`).
 
 // Prometheus metrics (STORY-1202). Exported so a host app can scrape the shared
 // `prom-client` registry directly (e.g. bolt it onto its own `/metrics` route)
@@ -78,11 +72,6 @@ export {
   OnMultipartCompleted,
 } from './lib/events/on-object-event.decorators';
 export { ObjectEventsService } from './lib/events/object-events.service';
-
-// The MikroORM contextName the lib registers under (phase 5 isolation). The
-// standalone app needs it to resolve the named ORM token in main.ts; a host
-// must not register its own MikroORM context with this name.
-export { OPEN_BUCKET_ORM_CONTEXT } from './lib/persistence/orm-context';
 
 // The multer storage engine + `@UploadedToBucket()` decorator + upload-validation
 // filter live behind the `@openbucket/nestjs/multer` SUBPATH export (STORY-1200).

--- a/libs/nestjs/src/lib/adapters/multer/index.ts
+++ b/libs/nestjs/src/lib/adapters/multer/index.ts
@@ -19,7 +19,6 @@ export { OpenBucketFileInterceptor } from './open-bucket-file.interceptor';
 
 export {
   UploadedToBucket,
-  uploadedToBucketFactory,
   type UploadedFileInfo,
 } from './uploaded-to-bucket.decorator';
 

--- a/libs/nestjs/src/lib/adapters/multer/open-bucket-storage.ts
+++ b/libs/nestjs/src/lib/adapters/multer/open-bucket-storage.ts
@@ -1,34 +1,27 @@
 import type { Request } from 'express';
 import type { StorageEngine } from 'multer';
 
-import type { OpenBucketService, PresignOptions } from '../../open-bucket.service';
+import type {
+  OpenBucketService,
+  PresignOptions,
+  UploadedObject,
+} from '../../open-bucket.service';
 import type {
   KeyStrategy,
   KeyStrategyName,
   UploadValidateOptions,
 } from '../../open-bucket-upload';
-import type { ImageInfo } from '../../storage/image-info';
 
 /**
  * The OpenBucket commit result the storage engine merges onto the multer file
  * object after a successful write. Read it via `@UploadedToBucket()` (or
  * `file.openBucket` directly). Carries no secret — `url`, when present, is a
  * short-lived presigned GET url.
+ *
+ * Alias of the canonical {@link UploadedObject} — the one shape `uploadFrom`,
+ * the storage engine, and `@UploadedToBucket()` all speak.
  */
-export interface OpenBucketMulterInfo {
-  bucket: string;
-  key: string;
-  /** Present iff an origin was resolvable / a `presign` option was given. */
-  url?: string;
-  etag: string;
-  /** The RESOLVED (sniffed) content type — never the client's unverified claim. */
-  contentType: string;
-  size: number;
-  /** Present on versioning-enabled buckets. */
-  versionId?: string;
-  /** Present when the body probed as an image. */
-  image?: ImageInfo;
-}
+export type OpenBucketMulterInfo = UploadedObject;
 
 // Augment the multer file shape so both the engine (which merges `openBucket`
 // onto the committed file) and `@UploadedToBucket()` (which reads it back) are

--- a/libs/nestjs/src/lib/adapters/multer/uploaded-to-bucket.decorator.ts
+++ b/libs/nestjs/src/lib/adapters/multer/uploaded-to-bucket.decorator.ts
@@ -1,7 +1,7 @@
 import { createParamDecorator, type ExecutionContext } from '@nestjs/common';
 import type { Request } from 'express';
 
-import type { ImageInfo } from '../../storage/image-info';
+import type { UploadedObject } from '../../open-bucket.service';
 // Loaded for its side-effect: the `Express.Multer.File.openBucket` global
 // augmentation this decorator reads back lives in `./open-bucket-storage`.
 import './open-bucket-storage';
@@ -11,21 +11,10 @@ import './open-bucket-storage';
  * {@link openBucketStorage}. Every field is already computed and non-secret; the
  * `contentType` is the RESOLVED (sniffed) type — never the client's claim — and
  * `url`, when present, is a short-lived presigned GET url (no long-lived secret).
+ *
+ * Alias of the canonical {@link UploadedObject}.
  */
-export interface UploadedFileInfo {
-  bucket: string;
-  key: string;
-  /** Present iff an origin was resolvable / a `presign` option was given. */
-  url?: string;
-  etag: string;
-  size: number;
-  /** The RESOLVED (sniffed) content type. */
-  contentType: string;
-  /** Present on versioning-enabled buckets. */
-  versionId?: string;
-  /** Present when the body probed as an image. */
-  image?: ImageInfo;
-}
+export type UploadedFileInfo = UploadedObject;
 
 /** Map a multer file to {@link UploadedFileInfo}, or `undefined` when it was not committed. */
 function toInfo(file: Express.Multer.File | undefined): UploadedFileInfo | undefined {

--- a/libs/nestjs/src/lib/domain/objects/object.service.ts
+++ b/libs/nestjs/src/lib/domain/objects/object.service.ts
@@ -391,9 +391,10 @@ export class ObjectService {
     body: Readable,
     contentType?: string,
     maxSize?: number,
+    userMetadata?: Record<string, string>,
   ): Promise<{ etag: string; versionId?: string; size: number; sha256?: string }> {
     if (!(await this.buckets.exists(bucket))) throw new NoSuchBucketError(bucket);
-    const row = await this.writer.put({ bucket, key, body, contentType, maxSize });
+    const row = await this.writer.put({ bucket, key, body, contentType, maxSize, userMetadata });
     return {
       etag: row.etag,
       versionId: row.currentVersionId,

--- a/libs/nestjs/src/lib/open-bucket-options.ts
+++ b/libs/nestjs/src/lib/open-bucket-options.ts
@@ -188,7 +188,26 @@ export interface OpenBucketModuleOptions {
   tracing?: { enabled?: boolean };
 }
 
-/** Async variant for DI'd secrets (e.g. from the host's ConfigService). */
+/**
+ * Implement this and pass the class via `useClass`/`useExisting` in
+ * {@link OpenBucketModuleAsyncOptions} to produce {@link OpenBucketModuleOptions}
+ * from an injectable provider (the idiomatic Nest alternative to an inline
+ * `useFactory`).
+ */
+export interface OpenBucketOptionsFactory {
+  createOpenBucketOptions(): Promise<OpenBucketModuleOptions> | OpenBucketModuleOptions;
+}
+
+/**
+ * Async variant for DI'd secrets (e.g. from the host's ConfigService). Provide
+ * the options one of three idiomatic ways — exactly one of `useFactory`,
+ * `useClass`, or `useExisting`:
+ *  - `useFactory` (+ `inject`): an inline factory function;
+ *  - `useClass`: a class implementing {@link OpenBucketOptionsFactory} — OpenBucket
+ *    registers it as a provider and calls `createOpenBucketOptions()`;
+ *  - `useExisting`: reuse an already-provided {@link OpenBucketOptionsFactory}
+ *    (e.g. exported by a module listed in `imports`).
+ */
 export interface OpenBucketModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
   /**
    * Route prefix — must be STATIC (known at module-config time, before the async
@@ -207,8 +226,20 @@ export interface OpenBucketModuleAsyncOptions extends Pick<ModuleMetadata, 'impo
    * `false` to run a headless, S3-only store.
    */
   admin?: boolean;
-  useFactory: (...args: unknown[]) => Promise<OpenBucketModuleOptions> | OpenBucketModuleOptions;
+  /** Inline factory that returns the options (optionally async). */
+  useFactory?: (...args: unknown[]) => Promise<OpenBucketModuleOptions> | OpenBucketModuleOptions;
+  /** DI dependencies injected into `useFactory` (positional). */
   inject?: Array<Type<unknown> | string | symbol>;
+  /**
+   * A class implementing {@link OpenBucketOptionsFactory}. OpenBucket registers it
+   * as a provider and calls `createOpenBucketOptions()` to build the options.
+   */
+  useClass?: Type<OpenBucketOptionsFactory>;
+  /**
+   * An existing provider implementing {@link OpenBucketOptionsFactory} (already
+   * provided by a module in `imports`, or elsewhere in the app).
+   */
+  useExisting?: Type<OpenBucketOptionsFactory>;
 }
 
 /** DI token carrying the fully-resolved (defaults-applied) options. */

--- a/libs/nestjs/src/lib/open-bucket.module.spec.ts
+++ b/libs/nestjs/src/lib/open-bucket.module.spec.ts
@@ -1,10 +1,11 @@
-import { Controller, Get, type INestApplication, Module } from '@nestjs/common';
+import { Controller, Get, Injectable, type INestApplication, Module } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import request from 'supertest';
 
 import { OpenBucketModule } from './open-bucket.module';
+import type { OpenBucketModuleOptions, OpenBucketOptionsFactory } from './open-bucket-options';
 
 /**
  * Host-app embedding harness — boots a NestJS app that imports
@@ -146,5 +147,52 @@ describe('OpenBucketModule.forRoot — admin disabled (headless S3-only)', () =>
       .post('/storage/api/admin/auth/login')
       .send({ username: 'admin', password: 'whatever' });
     expect(res.status).toBe(404);
+  });
+});
+
+const DATA_DIR_ASYNC = join(process.cwd(), 'tmp', `ob-async-useclass-${process.pid}`);
+
+// SF-2: `forRootAsync` supports `useClass`/`useExisting` via an
+// `OpenBucketOptionsFactory` (createOpenBucketOptions), not just `useFactory`.
+@Injectable()
+class TestOptionsFactory implements OpenBucketOptionsFactory {
+  createOpenBucketOptions(): OpenBucketModuleOptions {
+    // No `admin` block — the async `admin: false` runs this headless (S3-only).
+    return {
+      dataDir: DATA_DIR_ASYNC,
+      rootCredentials: {
+        accessKeyId: 'AKIAEXAMPLE000000000',
+        secretAccessKey: 'k7Jf2pQrwStN9vB3zX1cM4dL0eR6yU2h7gK3nP5s',
+      },
+    };
+  }
+}
+
+describe('OpenBucketModule.forRootAsync — useClass options factory', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    rmSync(DATA_DIR_ASYNC, { recursive: true, force: true });
+    mkdirSync(DATA_DIR_ASYNC, { recursive: true });
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        OpenBucketModule.forRootAsync({ admin: false, useClass: TestOptionsFactory }),
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+    rmSync(DATA_DIR_ASYNC, { recursive: true, force: true });
+  });
+
+  it('boots and serves S3 from options built by the injected factory (unsigned → 403)', async () => {
+    const res = await request(app.getHttpServer()).get('/storage/');
+    expect(res.status).toBe(403);
+    expect(res.headers['content-type']).toContain('xml');
   });
 });

--- a/libs/nestjs/src/lib/open-bucket.module.ts
+++ b/libs/nestjs/src/lib/open-bucket.module.ts
@@ -1,4 +1,4 @@
-import { DynamicModule, Module, type Type } from '@nestjs/common';
+import { DynamicModule, Module, type Provider, type Type } from '@nestjs/common';
 import { RouterModule } from '@nestjs/core';
 
 import { ADMIN_CONTROLLER_MODULES } from './admin/admin.module';
@@ -10,7 +10,9 @@ import {
   OPEN_BUCKET_OPTIONS,
   OpenBucketModuleAsyncOptions,
   OpenBucketModuleOptions,
+  OpenBucketOptionsFactory,
   resolveOptions,
+  ResolvedOpenBucketOptions,
   validateSecurityCriticalOptions,
 } from './open-bucket-options';
 import { OpenBucketService } from './open-bucket.service';
@@ -101,27 +103,10 @@ export class OpenBucketModule {
   static forRootAsync(options: OpenBucketModuleAsyncOptions): DynamicModule {
     // Whether the admin surface exists is a routing decision wired at module-config
     // time, so it is STATIC (default on). The admin SECRETS still come from the async
-    // factory; the factory must return an `admin` block unless `admin: false` here.
+    // provider; it must return an `admin` block unless `admin: false` here.
     const adminEnabled = options.admin ?? true;
     const coreModule = adminEnabled ? OpenBucketCoreModule : OpenBucketHeadlessCoreModule;
-    const optionsProvider = {
-      provide: OPEN_BUCKET_OPTIONS,
-      useFactory: async (...args: unknown[]) => {
-        const resolved = resolveOptions(await options.useFactory(...args));
-        if (adminEnabled && !resolved.admin) {
-          throw new Error(
-            'OpenBucketModule.forRootAsync: the admin surface is enabled but the factory ' +
-              'returned no `admin` config. Return an `admin` block, or pass `admin: false` ' +
-              'to disable the admin surface.',
-          );
-        }
-        // Fail fast on malformed secrets (bad hash, short jwt/secret) — same
-        // guarantee as the standalone env schema. See validateSecurityCriticalOptions.
-        validateSecurityCriticalOptions(resolved);
-        return resolved;
-      },
-      inject: options.inject ?? [],
-    };
+    const asyncProviders = OpenBucketModule.createAsyncProviders(options, adminEnabled);
     const serveUi = adminEnabled && (options.serveUi ?? true);
     return {
       module: OpenBucketModule,
@@ -138,8 +123,69 @@ export class OpenBucketModule {
           serveUi,
         ),
       ],
-      providers: [optionsProvider, OpenBucketService],
-      exports: [optionsProvider, OpenBucketService],
+      providers: [...asyncProviders, OpenBucketService],
+      exports: [OPEN_BUCKET_OPTIONS, OpenBucketService],
+    };
+  }
+
+  /**
+   * Build the DI providers backing `forRootAsync`: the resolved-options provider
+   * (from `useFactory` / `useClass` / `useExisting`) plus, for `useClass`, the
+   * factory class itself registered as a provider.
+   */
+  private static createAsyncProviders(
+    options: OpenBucketModuleAsyncOptions,
+    adminEnabled: boolean,
+  ): Provider[] {
+    const optionsProvider = OpenBucketModule.createAsyncOptionsProvider(options, adminEnabled);
+    // `useClass` must be instantiable by Nest, so register it as a provider too.
+    if (options.useClass) {
+      return [optionsProvider, { provide: options.useClass, useClass: options.useClass }];
+    }
+    return [optionsProvider];
+  }
+
+  /** The `OPEN_BUCKET_OPTIONS` provider, resolving + validating whatever the caller supplied. */
+  private static createAsyncOptionsProvider(
+    options: OpenBucketModuleAsyncOptions,
+    adminEnabled: boolean,
+  ): Provider {
+    // Shared post-processing: apply defaults, enforce the admin invariant, and
+    // fail fast on malformed secrets — identical to the sync `forRoot` guarantee.
+    const finalize = (raw: OpenBucketModuleOptions): ResolvedOpenBucketOptions => {
+      const resolved = resolveOptions(raw);
+      if (adminEnabled && !resolved.admin) {
+        throw new Error(
+          'OpenBucketModule.forRootAsync: the admin surface is enabled but the options ' +
+            'provider returned no `admin` config. Return an `admin` block, or pass ' +
+            '`admin: false` to disable the admin surface.',
+        );
+      }
+      validateSecurityCriticalOptions(resolved);
+      return resolved;
+    };
+
+    if (options.useFactory) {
+      return {
+        provide: OPEN_BUCKET_OPTIONS,
+        useFactory: async (...args: unknown[]) => finalize(await options.useFactory!(...args)),
+        inject: options.inject ?? [],
+      };
+    }
+
+    // useClass / useExisting: inject the factory provider and call its hook.
+    const factoryToken = options.useExisting ?? options.useClass;
+    if (!factoryToken) {
+      throw new Error(
+        'OpenBucketModule.forRootAsync: provide exactly one of `useFactory`, `useClass`, ' +
+          'or `useExisting`.',
+      );
+    }
+    return {
+      provide: OPEN_BUCKET_OPTIONS,
+      useFactory: async (factory: OpenBucketOptionsFactory) =>
+        finalize(await factory.createOpenBucketOptions()),
+      inject: [factoryToken],
     };
   }
 }

--- a/libs/nestjs/src/lib/open-bucket.service.spec.ts
+++ b/libs/nestjs/src/lib/open-bucket.service.spec.ts
@@ -83,6 +83,26 @@ describe('OpenBucketService — in-process facade', () => {
     expect(folders.commonPrefixes.sort()).toEqual(['docs/', 'images/']);
   });
 
+  it('putObject persists userMetadata that headObject reads back (SF-4)', async () => {
+    await svc.putObject(BUCKET, 'docs/meta-put.txt', 'x', {
+      contentType: 'text/plain',
+      userMetadata: { owner: 'alice', tier: 'gold' },
+    });
+    const meta = await svc.headObject(BUCKET, 'docs/meta-put.txt');
+    expect(meta!.userMetadata).toEqual({ owner: 'alice', tier: 'gold' });
+  });
+
+  it('uploadFrom persists userMetadata that headObject reads back (SF-4)', async () => {
+    const res = await svc.uploadFrom(Buffer.from('hello'), {
+      bucket: BUCKET,
+      key: 'docs/meta-upload.txt',
+      contentType: 'text/plain',
+      userMetadata: { source: 'unit-test' },
+    });
+    const meta = await svc.headObject(BUCKET, res.key);
+    expect(meta!.userMetadata).toEqual({ source: 'unit-test' });
+  });
+
   it('deletes an object (idempotently)', async () => {
     await svc.putObject(BUCKET, 'tmp/x', 'x');
     await svc.deleteObject(BUCKET, 'tmp/x');

--- a/libs/nestjs/src/lib/open-bucket.service.ts
+++ b/libs/nestjs/src/lib/open-bucket.service.ts
@@ -11,10 +11,7 @@ import { OPEN_BUCKET_OPTIONS, type ResolvedOpenBucketOptions } from './open-buck
 import { OPEN_BUCKET_ORM_CONTEXT } from './persistence/orm-context';
 import { NoSuchKeyError } from './s3/errors/s3-error';
 import { buildPresignedUrl, MAX_EXPIRES } from './s3/sigv4/presigned';
-import {
-  buildPresignedPost,
-  type PostPolicyCondition,
-} from './s3/sigv4/presigned-post';
+import { buildPresignedPost } from './s3/sigv4/presigned-post';
 import { SNIFF_BYTES, sniffContentType } from './storage/content-sniff';
 import { imageInfo, type ImageInfo } from './storage/image-info';
 import {
@@ -69,14 +66,30 @@ export interface UploadOptions {
   contentType?: string;
   /** Filename hint for the `'original'` strategy / extension (multer `originalname` used when omitted). */
   filename?: string;
+  /**
+   * Arbitrary user metadata persisted with the object and returned by
+   * {@link OpenBucketService.headObject} (`userMetadata`).
+   */
+  userMetadata?: Record<string, string>;
   /** Probe image dimensions. Default: auto for `image/*` resolved types. */
   image?: boolean;
   /** Mint a GET url; default: mint iff an origin (`baseUrl`/`endpoint`) is resolvable. `false` disables. */
   presign?: PresignOptions | false;
 }
 
-/** Result of {@link OpenBucketService.uploadFrom}. */
-export interface UploadResult {
+/**
+ * The canonical shape of an object committed through OpenBucket's upload path —
+ * the stable `{ bucket, key, url?, etag, size, contentType, versionId?, image? }`
+ * you should persist. Returned by {@link OpenBucketService.uploadFrom}, merged
+ * onto the multer file by the `@openbucket/nestjs/multer` storage engine
+ * (`OpenBucketMulterInfo`), and handed to a handler by `@UploadedToBucket()`
+ * (`UploadedFileInfo`) — those two names are aliases of this one type.
+ *
+ * Carries no secret: `contentType` is the RESOLVED (sniffed) type — never the
+ * client's unverified claim — and `url`, when present, is a short-lived presigned
+ * GET url.
+ */
+export interface UploadedObject {
   bucket: string;
   key: string;
   /** Present when an origin was resolvable (or `presign.baseUrl` was given). */
@@ -90,6 +103,9 @@ export interface UploadResult {
   /** Present when the body was probed as an image. */
   image?: ImageInfo;
 }
+
+/** Result of {@link OpenBucketService.uploadFrom}. Alias of {@link UploadedObject}. */
+export type UploadResult = UploadedObject;
 
 /** One object (or rolled-up prefix) in a listing. */
 export interface ObjectListEntry {
@@ -126,6 +142,50 @@ export interface BucketInfo {
   name: string;
   createdAt: Date;
 }
+
+/** Options for {@link OpenBucketService.createBucket}. */
+export interface CreateBucketOptions {
+  /** Enable object versioning at creation. Default `false`. */
+  versioning?: boolean;
+  /** Enable S3 object lock at creation. Default `false`. */
+  objectLock?: boolean;
+}
+
+/** Options for {@link OpenBucketService.putObject}. */
+export interface PutObjectOptions {
+  /** Declared content type stored with the object. Default `application/octet-stream`. */
+  contentType?: string;
+  /**
+   * Arbitrary user metadata persisted with the object and returned by
+   * {@link OpenBucketService.headObject} (`userMetadata`). Keys/values are stored
+   * verbatim.
+   */
+  userMetadata?: Record<string, string>;
+}
+
+/** Options for {@link OpenBucketService.listObjects}. */
+export interface ListObjectsOptions {
+  /** Only keys under this prefix. */
+  prefix?: string;
+  /** Roll keys up into `commonPrefixes` at this delimiter (folder-style browsing). */
+  delimiter?: string;
+  /** Pagination cursor — pass back the previous page's `nextMarker`. */
+  marker?: string;
+  /** Max keys per page (hard-capped at 1000). Default 1000. */
+  limit?: number;
+}
+
+/**
+ * A single S3 POST-policy condition (AWS-compatible forms) — the escape-hatch
+ * `conditions` on {@link PresignPostOptions}. Re-homed here (from the internal
+ * SigV4 crypto module) so the public export is not coupled to an internal file
+ * path; the crypto core imports this same type back.
+ */
+export type PostPolicyCondition =
+  | Record<string, string> // exact match: { key: 'uploads/a.png' }
+  | ['eq', string, string] // ['eq', '$key', 'uploads/a.png']
+  | ['starts-with', string, string] // ['starts-with', '$key', 'uploads/']
+  | ['content-length-range', number, number];
 
 /** Options for minting a presigned browser POST (direct upload form). */
 export interface PresignPostOptions {
@@ -226,10 +286,7 @@ export class OpenBucketService {
    * Create a bucket. Throws `BucketAlreadyOwnedByYouError` if it already exists.
    * Set `versioning`/`objectLock` to enable those features at creation.
    */
-  createBucket(
-    name: string,
-    opts: { versioning?: boolean; objectLock?: boolean } = {},
-  ): Promise<void> {
+  createBucket(name: string, opts: CreateBucketOptions = {}): Promise<void> {
     return this.withContext(async () => {
       await this.buckets.create({
         name,
@@ -256,10 +313,12 @@ export class OpenBucketService {
     bucket: string,
     key: string,
     body: Readable | Buffer | string,
-    opts: { contentType?: string } = {},
+    opts: PutObjectOptions = {},
   ): Promise<PutObjectResult> {
     const stream = body instanceof Readable ? body : Readable.from(body);
-    return this.withContext(() => this.objects.putFromStream(bucket, key, stream, opts.contentType));
+    return this.withContext(() =>
+      this.objects.putFromStream(bucket, key, stream, opts.contentType, undefined, opts.userMetadata),
+    );
   }
 
   /**
@@ -311,18 +370,19 @@ export class OpenBucketService {
       const ext = sanitizeFilename(filename).ext;
       const strategy = opts.keyStrategy ?? 'uuid';
       const ctx: KeyStrategyContext = { filename, contentType: resolvedType, ext };
+      const meta = opts.userMetadata;
 
       let key: string;
       let write: { etag: string; versionId?: string; size: number; sha256?: string };
 
       if (opts.key) {
         key = opts.key;
-        write = await this.objects.putFromStream(opts.bucket, key, stream, resolvedType, maxBytes);
+        write = await this.objects.putFromStream(opts.bucket, key, stream, resolvedType, maxBytes, meta);
       } else if (strategy === 'sha256' && Buffer.isBuffer(norm.body)) {
         // Content-addressed, buffer fast path: hash directly, write once.
         const sha256 = createHash('sha256').update(norm.body).digest('hex');
         key = resolveKey('sha256', { ...ctx, sha256 });
-        write = await this.objects.putFromStream(opts.bucket, key, stream, resolvedType, maxBytes);
+        write = await this.objects.putFromStream(opts.bucket, key, stream, resolvedType, maxBytes, meta);
       } else if (strategy === 'sha256') {
         // Content-addressed, stream path: the digest is only known post-write, so
         // stage under a temp key, then relocate to the digest key (idempotent on
@@ -333,12 +393,13 @@ export class OpenBucketService {
           resolvedType,
           maxBytes,
           ctx,
+          meta,
         );
         key = staged.key;
         write = staged;
       } else {
         key = resolveKey(strategy, ctx);
-        write = await this.objects.putFromStream(opts.bucket, key, stream, resolvedType, maxBytes);
+        write = await this.objects.putFromStream(opts.bucket, key, stream, resolvedType, maxBytes, meta);
       }
 
       const url = this.resolveUploadUrl(opts.bucket, key, opts.presign);
@@ -370,6 +431,7 @@ export class OpenBucketService {
     resolvedType: string,
     maxBytes: number,
     ctx: KeyStrategyContext,
+    userMetadata?: Record<string, string>,
   ): Promise<{ key: string; etag: string; versionId?: string; size: number; sha256?: string }> {
     const stagingKey = `_ob-staging/${randomUUID()}`;
     const staged = await this.objects.putFromStream(bucket, stagingKey, stream, resolvedType, maxBytes);
@@ -389,7 +451,14 @@ export class OpenBucketService {
 
     const opened = await this.objects.openObjectStream(bucket, stagingKey);
     if (!opened) throw new NoSuchKeyError(stagingKey);
-    const finalWrite = await this.objects.putFromStream(bucket, key, opened.stream, resolvedType);
+    const finalWrite = await this.objects.putFromStream(
+      bucket,
+      key,
+      opened.stream,
+      resolvedType,
+      undefined,
+      userMetadata,
+    );
     await this.objects.delete(bucket, stagingKey);
     return { key, ...finalWrite };
   }
@@ -494,10 +563,7 @@ export class OpenBucketService {
    * (folder-style browsing); page with `marker` (pass back the previous page's
    * `nextMarker`). `limit` defaults to 1000.
    */
-  listObjects(
-    bucket: string,
-    opts: { prefix?: string; delimiter?: string; marker?: string; limit?: number } = {},
-  ): Promise<ObjectListResult> {
+  listObjects(bucket: string, opts: ListObjectsOptions = {}): Promise<ObjectListResult> {
     return this.withContext(() =>
       this.objects.list({
         bucket,

--- a/libs/nestjs/src/lib/s3/sigv4/presigned-post.ts
+++ b/libs/nestjs/src/lib/s3/sigv4/presigned-post.ts
@@ -6,8 +6,12 @@ import {
   EntityTooSmallError,
   MalformedPolicyError,
 } from '../errors/s3-error';
+import type { PostPolicyCondition } from '../../open-bucket.service';
+
 import { awsUriEncode } from './canonical-request';
 import { constantTimeEquals, deriveSigningKey } from './sigv4.verifier';
+
+export type { PostPolicyCondition };
 
 /**
  * POST-policy crypto core for S3 browser uploads (WHITEPAPER §2.5.1), symmetric
@@ -18,13 +22,6 @@ import { constantTimeEquals, deriveSigningKey } from './sigv4.verifier';
  * `conditions` against the submitted form fields, and re-derives + constant-time
  * compares the signature.
  */
-
-/** A single S3 POST-policy condition (AWS-compatible forms). */
-export type PostPolicyCondition =
-  | Record<string, string> // exact match: { key: 'uploads/a.png' }
-  | ['eq', string, string] // ['eq', '$key', 'uploads/a.png']
-  | ['starts-with', string, string] // ['starts-with', '$key', 'uploads/']
-  | ['content-length-range', number, number];
 
 /** An S3 POST policy document. */
 export interface PostPolicy {

--- a/libs/nestjs/src/standalone.ts
+++ b/libs/nestjs/src/standalone.ts
@@ -1,0 +1,32 @@
+/**
+ * `@openbucket/nestjs/standalone` — composition-root internals.
+ *
+ * These symbols exist ONLY so the first-party standalone backend (and the
+ * openapi-export tooling) can bootstrap OpenBucket from the published package.
+ * They are NOT part of the host-app API surface (`OpenBucketModule.forRoot(…)` +
+ * `OpenBucketService`) and are intentionally kept OFF the main `.` entry so they
+ * are not frozen as public API: the composition-root modules, the env-driven
+ * `AppConfigService`, the admin/health module handles used by the OpenAPI export,
+ * the two mount helpers `main.ts` needs, and the named ORM context token.
+ *
+ * Host apps should NOT import from here — use the `.` entry.
+ */
+export { OpenBucketCoreModule } from './lib/open-bucket-core.module';
+export { OpenBucketStandaloneModule } from './lib/open-bucket-standalone.module';
+export { AdminModule } from './lib/admin/admin.module';
+export { HealthModule } from './lib/admin/health/health.module';
+
+// The two pure helpers `main.ts` needs to be mount-aware without duplicating
+// logic — `normalizeMount` (the same normalization the env schema + `forRoot`
+// apply) and `rewriteBaseHref` (the SPA `<base href>` rewrite the embedded
+// SpaController uses).
+export { normalizeMount } from './lib/open-bucket-options';
+export { rewriteBaseHref } from './lib/spa/spa-utils';
+
+// Config service consumed by the standalone app's main.ts (phase 0b).
+export { AppConfigService } from './lib/common/config/app-config.service';
+
+// The MikroORM contextName the lib registers under (phase 5 isolation). The
+// standalone app needs it to resolve the named ORM token in main.ts; a host
+// must not register its own MikroORM context with this name.
+export { OPEN_BUCKET_ORM_CONTEXT } from './lib/persistence/orm-context';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,7 @@
     "paths": {
       "@openbucket/api-client": ["libs/api-client/src/index.ts"],
       "@openbucket/nestjs": ["libs/nestjs/src/index.ts"],
+      "@openbucket/nestjs/standalone": ["libs/nestjs/src/standalone.ts"],
       "@openbucket/spartan-ui/accordion": [
         "libs/ui/spartan/accordion/src/index.ts"
       ],


### PR DESCRIPTION
Pre-1.0 public API-surface cleanup for `@openbucket/nestjs`, from an API review. All items are additive or non-breaking (old names/imports preserved as aliases).

## Changes

- **MF-4 — `@openbucket/nestjs/standalone` subpath.** Moved the composition-root internals that only the first-party standalone backend needs off the frozen `.` entry into a new `libs/nestjs/src/standalone.ts` barrel: `OpenBucketCoreModule`, `OpenBucketStandaloneModule`, `AppConfigService`, `AdminModule`, `HealthModule`, `normalizeMount`, `rewriteBaseHref`, `OPEN_BUCKET_ORM_CONTEXT`. Added the `./standalone` entry to `package.json` `exports` (mirrors `./multer`) + a `tsconfig.base.json` path, and repointed `apps/openbucket-backend/src/main.ts` and `src/openapi-export.ts`. The `.` entry keeps `OpenBucketModule`, `OpenBucketService` + its types, the option interfaces, the upload/validation model, the metrics registry, and the object-events surface.
- **MF-5 — Unify the three upload-result types.** `UploadResult`, `OpenBucketMulterInfo`, and `UploadedFileInfo` now all alias a single canonical `UploadedObject` (defined + exported from the service module). No importer breaks — every old name is still exported.
- **SF-4 — Writable `userMetadata`.** Added optional `userMetadata?: Record<string,string>` to `putObject` (`PutObjectOptions`) and `uploadFrom` (`UploadOptions`), threaded through `ObjectService.putFromStream` into the existing `ObjectWriterService` metadata column. What you read via `headObject().userMetadata` you can now write.
- **SF-5 — Drop the multer test-seam.** Removed `uploadedToBucketFactory` from the public `@openbucket/nestjs/multer` barrel; it stays internal and its spec imports it by module path.
- **SF-2 — `useClass` / `useExisting` async options.** Added `OpenBucketOptionsFactory` (`createOpenBucketOptions()`) and wired `useClass`/`useExisting` into `forRootAsync`; `useFactory` is unchanged.
- **NH-2 — Re-home `PostPolicyCondition`.** The canonical definition now lives next to the other service types; the internal SigV4 crypto core imports it back. The public export no longer references the deep `s3/sigv4/presigned-post` path (name unchanged).
- **NH-4 — Named option interfaces.** Extracted + exported `CreateBucketOptions`, `PutObjectOptions`, `ListObjectsOptions` for `createBucket`/`putObject`/`listObjects`.

## Verification

- `npx nx build nestjs` ✅ and `npx nx build openbucket-backend` ✅ (backend compiles against the moved `/standalone` exports).
- `npx nx test nestjs` ✅ — 138 suites / 1202 tests pass (added SF-2 `useClass` boot test + SF-4 `userMetadata` round-trip tests).
- `npx nx lint nestjs` ✅ 0 errors; `npx nx lint openbucket-backend` ✅ 0 errors.
- `npx nx openapi:export openbucket-backend` ✅ runs against `/standalone` (48 paths).
- Grep confirms no source imports the moved symbols from the bare `@openbucket/nestjs` — they come from `/standalone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)