### PR TITLE
chore(ci): least-privilege top-level permissions on release/codeql workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "27 3 * * 1" # Mondays 03:27 UTC
 
+# Least-privilege default; the analyze job elevates to what CodeQL needs.
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -28,6 +28,10 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+# Least-privilege default; the publish job elevates (contents:read, packages:write).
+permissions:
+  contents: read
+
 concurrency:
   group: release-docker-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/release-nestjs.yml
+++ b/.github/workflows/release-nestjs.yml
@@ -26,6 +26,10 @@ on:
     tags: ['v*', 'nestjs-v*']
   workflow_dispatch:
 
+# Least-privilege default; the publish job elevates (contents:write, id-token:write).
+permissions:
+  contents: read
+
 concurrency:
   group: release-nestjs-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
`codeql.yml`, `release-nestjs.yml`, and `release-docker.yml` had no top-level `permissions:` block — the OpenSSF Scorecard **TokenPermissions (high)** finding, and the main source of the recurring red code-scanning check on PRs (which nearly let a real alert hide on #64).

Adds a least-privilege `permissions: contents: read` default to each. **No behavior change** — every job already declares the elevated permissions it needs (`packages:write` / `contents:write` / `id-token:write` / `security-events:write`), which override the top-level default.

(Skipped the mass SHA-pinning of GitHub-owned actions — higher churn, lower value — as a separate optional pass.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)