### PR TITLE
docs: add Google Search Console site-verification meta tag

### DIFF
--- a/apps/docs/docusaurus.config.js
+++ b/apps/docs/docusaurus.config.js
@@ -137,6 +137,13 @@ const config = {
             'S3-compatible, object store, self-hosted, NestJS, S3 API, SigV4, presigned URLs, MinIO alternative, self-hosted S3, Docker, Node.js, TypeScript',
         },
         {name: 'author', content: 'OpenBucket contributors'},
+        // Google Search Console ownership verification for the URL-prefix
+        // property https://projectbay.github.io/openbucket/ — must stay in
+        // place permanently (Google rechecks it periodically).
+        {
+          name: 'google-site-verification',
+          content: '385QXR-SSO8L38WaH39K5Su1q3j0_B0ZcK-LHq0CCeY',
+        },
       ],
       colorMode: {
         respectPrefersColorScheme: true,


### PR DESCRIPTION
Adds the `google-site-verification` meta tag to the Docusaurus global metadata so the URL-prefix property `https://projectbay.github.io/openbucket/` can be verified in Google Search Console.

The tag must remain in place permanently — Google periodically rechecks ownership.

Verified locally: `npm run build` succeeds and the tag renders in `build/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)