### PR TITLE
docs(blog): 14 posts — tutorials, deep-dives, comparisons (wave 1)

### DIFF
--- a/apps/docs/blog/2026-07-16-our-backups-were-lying.md
+++ b/apps/docs/blog/2026-07-16-our-backups-were-lying.md
@@ -1,0 +1,189 @@
+---
+slug: our-backups-were-lying
+title: 'Our backups were lying to us: what a restore drill caught before 1.0'
+description: A pre-1.0 restore drill caught our v1 backups silently dropping version history and encryption config. What we fixed — and why you should drill yours.
+authors: [openbucket]
+tags: [backup, restore, post-mortem, data-safety, s3, self-hosted]
+date: 2026-07-16
+keywords:
+  [
+    test backup restore,
+    backup restore drill,
+    verify backups work,
+    s3 backup fidelity,
+    self-hosted object storage backup,
+    restore testing best practices,
+  ]
+---
+
+OpenBucket has had backup and restore for a while: hit one endpoint, get a
+portable `.zip` of your whole instance, upload it later to rebuild. The e2e test
+was green. The console button worked. We would have told you — honestly, in good
+faith — that backups were done.
+
+Then, on the road to 1.0, we ran a proper restore drill: back up a fully-loaded
+instance and restore it into a **pristine, separate one**. The archive restored
+"successfully" — and silently dropped object version history, and rewrote
+encrypted objects to disk as **plaintext**. This is the post-mortem, and the
+argument for why you should drill your own restores this week, whatever store
+you use.
+
+<!-- truncate -->
+
+## Why we drilled at all
+
+The backup test we already had did a round-trip: create objects, back up,
+restore, check the keys and bytes match. It passed. But it restored **into the
+same running instance** — the instance that still held every bucket's config,
+its SQLite metadata, and its encryption key. Any state the restore failed to
+rebuild was invisibly papered over by state that had never left.
+
+That's not the question a backup exists to answer. The real question is: *the
+data volume is gone, or you're migrating hosts — can this `.zip` alone rebuild
+your instance?* Before calling the data path 1.0-ready, we wrote an e2e drill
+that asks exactly that
+([`backup-restore-fidelity.e2e-spec.ts`](https://github.com/ProjectBay/openbucket/blob/main/apps/openbucket-backend-e2e/src/backup-restore-fidelity.e2e-spec.ts)),
+and it now runs in CI on every change.
+
+## The drill
+
+The setup is deliberately worst-case realistic:
+
+1. **Spawn instance A** and load it with rich state: a versioning-enabled bucket
+   holding **three versions** of the same key; an object with a custom
+   `Content-Type`, user metadata, and tags; a bucket with **default SSE-S3
+   encryption** holding a secret object (verified to be ciphertext on A's disk);
+   plus lifecycle rules, a CORS config, and a bucket policy.
+2. **Take a whole-instance backup** — the same endpoint you'd use:
+
+   ```bash
+   curl -sS http://localhost:9000/api/admin/backup \
+     -H "Authorization: Bearer $ADMIN_JWT" \
+     -o openbucket-snapshot.zip
+   ```
+
+3. **Spawn a pristine instance B** — new data directory, fresh migrations, and,
+   crucially, a **different auto-generated SSE key** (the drill asserts A's and
+   B's keys differ).
+4. **Restore into B** and diff *everything* against A: bytes, metadata, tags,
+   versioning status, version history, bucket config — and the raw blob files
+   on B's disk.
+
+   ```bash
+   curl -sS -X POST http://localhost:9000/api/admin/restore \
+     -H "Authorization: Bearer $ADMIN_JWT" \
+     --data-binary @openbucket-snapshot.zip
+   ```
+
+## What it caught
+
+Current object bytes, content types, user metadata, tags, and versioning status
+all survived. The rest did not.
+
+**The scary one: a silent encryption downgrade.** A backup archive contains
+decrypted bytes (documented and by design — the target instance has a different
+key). On restore, the v1 code recreated the bucket but **dropped its
+default-encryption config** — so the object writer had no reason to encrypt, and
+the restored blob landed on B's disk as plaintext. Every read still returned the
+right bytes. Nothing errored. Nothing logged. You'd only notice if you opened
+the blob file on disk — which is exactly what the drill does, grepping the raw
+file for the secret marker string.
+
+**Version history: gone.** A had three versions of `doc.txt`; B had one. The v1
+manifest captured only the current pointer per key, so the entire prior history
+— the thing versioning exists to protect — evaporated on restore.
+
+**Lifecycle, CORS, and bucket policy: gone.** Expiration rules stopped firing,
+browsers lost their CORS grants, and a bucket that had a policy came back with
+none.
+
+The drill also surfaced two unrelated S3 read-path gaps while we were asserting
+fidelity — `HEAD` didn't emit stored `x-amz-meta-*` headers, and `GET`/`HEAD`
+didn't honour `?versionId`. Both were fixed in the same release
+([v0.1.0-alpha.20](https://github.com/ProjectBay/openbucket/blob/main/CHANGELOG.md)).
+Drills have a way of paying twice.
+
+## Why v1 got it wrong
+
+Not carelessness — a framing error. The v1 backup captured what was **easy to
+enumerate**: walk the buckets, walk the current objects, stream bytes plus the
+obvious per-object metadata. That's a snapshot of what the instance *contains*.
+
+But an instance isn't just its contents. It's also **configuration that shapes
+future behavior** (default encryption, lifecycle, CORS, policy) and **history**
+(prior versions). None of that shows up when you iterate "the objects", and a
+same-instance round-trip test can't miss it — the live instance still supplies
+it. The moment the restore target was genuinely empty, everything the manifest
+didn't carry simply ceased to exist.
+
+## The fix: manifest v2
+
+The manifest now captures the full per-bucket config and, for versioned keys,
+every stored version:
+
+```ts
+interface BackupManifest {
+  version: 1 | 2;
+  kind: 'bucket' | 'instance';
+  createdAt: string;
+  buckets: BackupBucketConfig[]; // v2: + encryption/lifecycle/cors/policy/tagging
+  objects: BackupObject[];
+  /** v2 only — full version history, oldest→newest per key. */
+  objectVersions?: BackupVersion[];
+}
+```
+
+Three design decisions mattered more than the fields themselves:
+
+**Ordering: config before bytes.** On restore, each bucket's captured config is
+applied **before** any object payload is written — encryption first, then
+versioning, then lifecycle/CORS/policy. Because the encryption default exists by
+the time bytes arrive, the object writer re-encrypts every restored blob **under
+the target instance's own key**. The drill asserts this at the filesystem level:
+B's blob is ciphertext under B's key, and still decrypts correctly on read.
+
+**History is replayed, not copied.** Version entries are authored oldest→newest
+per key, and the restore replays each write in order — delete markers landing in
+their exact historical position — so the target rebuilds a real history with a
+correct current pointer. Version IDs are regenerated on replay; the *history* is
+what's preserved, not the identifiers.
+
+**Additive fields only.** Every v2 field is optional, so **v1 archives still
+restore** — they just fall back to the old behavior (current versions, no bucket
+config). A backup format that invalidates existing backups would be its own kind
+of data loss.
+
+Full details are in the [backup and restore guide](/docs/guides/backup-and-restore)
+— including the honest caveats: restore is a **reset**, not a merge, and
+snapshot archives contain decrypted bytes, so handle them like the data itself
+(see [securing OpenBucket](/docs/guides/securing-openbucket)).
+
+## A backup is a claim; only a restore is a proof
+
+Here's the part that matters even if you never touch OpenBucket. Our backups
+"worked" for months by every signal we had: green tests, valid archives,
+successful restore responses. The lie wasn't in any of those signals — it was in
+what we never asked. **A backup is a claim about the future. Only a restore into
+a genuinely empty environment turns it into a proof.**
+
+So run the drill, whatever your stack — Postgres dumps, S3 bucket sync, VM
+snapshots:
+
+- Restore into a **pristine target**, never the system that made the backup.
+- Diff **properties**, not just bytes: permissions, encryption at rest,
+  retention/lifecycle rules, history, policies.
+- Check the **storage layer directly** where security properties live — a
+  plaintext-on-disk downgrade is invisible from the read path.
+- **Automate it.** Ours is a CI test now; fidelity can't silently regress.
+
+OpenBucket is still pre-1.0 and single-node by design — we won't promise you
+distributed durability. What we can promise is that the restore path is proven
+by a drill on every commit, not asserted by a changelog.
+
+---
+
+Found this useful? A star on
+[GitHub](https://github.com/ProjectBay/openbucket) helps more people find
+OpenBucket — and if you run your own restore drill and it catches something,
+we'd genuinely love to hear the war story in
+[Discussions](https://github.com/ProjectBay/openbucket/discussions).

--- a/apps/docs/blog/2026-07-22-direct-browser-uploads-presigned-post.md
+++ b/apps/docs/blog/2026-07-22-direct-browser-uploads-presigned-post.md
@@ -1,0 +1,229 @@
+---
+slug: direct-browser-uploads-presigned-post
+title: Direct browser uploads with presigned POST — no bytes through your backend
+description: Let browsers upload straight to your self-hosted S3 store with presigned POST. Your NestJS server only signs a short-lived policy — full tutorial.
+authors: [openbucket]
+tags: [nestjs, tutorial, presigned-post, file-upload, s3, browser-uploads]
+date: 2026-07-22
+keywords:
+  [
+    s3 presigned post browser upload,
+    direct browser upload to s3,
+    presigned url upload nestjs,
+    s3 post policy tutorial,
+    upload file from browser to s3,
+    self-hosted s3 presigned post,
+  ]
+draft: true
+---
+
+In [the last tutorial](/blog/nestjs-file-uploads-in-10-minutes) we built a
+`POST /files` endpoint where the browser uploads to your NestJS app and the file
+streams into OpenBucket. That's a fine default — but notice what happens to every
+byte: it enters your server once (browser → API) and leaves it again (API →
+store). Double the bandwidth, and your Node process babysits the connection for
+the whole transfer. For avatars, who cares. For a 200 MB video, it adds up fast.
+
+**Presigned POST** flips the flow. Your server's only job is to sign a
+short-lived policy — a few hundred bytes of JSON — and the browser POSTs the file
+**directly to the object store**. No S3 SDK in the browser, no credentials
+leaving your server, no file bytes touching your API. Here's the whole thing
+end-to-end with OpenBucket.
+
+<!-- truncate -->
+
+## The flow in three steps
+
+1. The browser asks your API: "I want to upload `cat.png`, may I?"
+2. Your API mints a **presigned POST** — a `url` plus a set of hidden form
+   `fields` containing a signed, expiring policy that says *exactly* what may be
+   uploaded (which key, what content type, how many bytes).
+3. The browser builds a `FormData` from those fields, appends the file **last**,
+   and POSTs it straight to the store. OpenBucket verifies the signature and the
+   policy conditions before a single byte is committed.
+
+This post assumes the setup from the
+[10-minute tutorial](/blog/nestjs-file-uploads-in-10-minutes): `@openbucket/nestjs`
+mounted at `/storage`, secrets in place, and a bucket created on boot — we'll use
+one called `avatars`.
+
+## Step 1 — The endpoint that mints the token
+
+Inject `OpenBucketService` and call `createPresignedPost`. It's pure crypto — no
+database or filesystem access — so it's cheap to call per upload. We mint an
+exact key server-side so both the browser and your database know it up front, with
+no response parsing:
+
+```ts title="files.controller.ts"
+import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
+import { OpenBucketService } from '@openbucket/nestjs';
+import { randomUUID } from 'node:crypto';
+
+@Controller('files')
+export class FilesController {
+  constructor(private readonly ob: OpenBucketService) {}
+
+  @Get('upload-token')
+  uploadToken(@Query('filename') filename?: string) {
+    const base = (filename ?? '').replace(/^.*[\\/]/, ''); // strip any path
+    if (!base) throw new BadRequestException('filename is required');
+
+    const key = `users/${randomUUID()}-${base}`;
+    const { url, fields } = this.ob.createPresignedPost('avatars', {
+      key, // exact-match condition: this token uploads THIS key, nothing else
+      expiresIn: 300, // seconds; default 900, capped at 7 days
+      contentType: { startsWith: 'image/' }, // or pin one: 'image/png'
+      contentLengthRange: { min: 1, max: 5 * 1024 * 1024 }, // 1 B … 5 MiB
+      successActionStatus: '201',
+      baseUrl: 'http://localhost:3000', // your public origin; or set the
+      //                                   module's `endpoint` option once
+    });
+    return { url, fields, key };
+  }
+}
+```
+
+`url` is where the browser POSTs (`http://localhost:3000/storage/avatars` here —
+origin + `mountPath` + bucket), and `fields` are the hidden inputs carrying the
+base64 policy and its SigV4 signature.
+
+Two options worth knowing: `key: 'users/${filename}'` (a literal placeholder,
+substituted server-side from the uploaded filename) and `keyStartsWith: true`,
+which turns the key into a prefix — a folder-scoped upload token. The full option
+table is in the [sharing files guide](/docs/guides/sharing-files).
+
+## Step 2 — The browser upload
+
+No SDK needed — `fetch` and `FormData` do it all. Order matters: every minted
+field first, the file part **last** (that's the S3 POST contract, and OpenBucket
+ignores fields that arrive after the file):
+
+```js title="upload.js"
+async function upload(file) {
+  // 1. Ask your API for a signed form.
+  const res = await fetch(
+    `/files/upload-token?filename=${encodeURIComponent(file.name)}`,
+  );
+  const { url, fields, key } = await res.json();
+
+  // 2. Build the form: minted fields, then Content-Type, then the file LAST.
+  const form = new FormData();
+  for (const [name, value] of Object.entries(fields)) form.append(name, value);
+  form.append('Content-Type', file.type); // required with a startsWith policy
+  form.append('file', file);
+
+  // 3. POST straight to the store — bytes never touch your API.
+  const upload = await fetch(url, { method: 'POST', body: form });
+  if (!upload.ok) throw new Error(`upload failed: ${upload.status}`);
+
+  return key; // hand this to your API to persist in your DB
+}
+```
+
+That explicit `Content-Type` field is easy to miss: with
+`contentType: { startsWith: 'image/' }` the policy contains a
+`starts-with $Content-Type` condition but no fixed value, so the browser must
+supply the field itself — omit it and the upload is rejected with a 403. (If you
+pin an exact type instead, it's already in `fields` and you can skip that line.)
+
+On success you get `201` with a small `<PostResponse>` XML body (key + ETag)
+because we asked for `successActionStatus: '201'`; without it, OpenBucket answers
+`204 No Content`. There's also `successActionRedirect` for the no-JavaScript
+variant — a plain `<form method="post" enctype="multipart/form-data">` with the
+minted fields as hidden inputs works too, and the redirect bounces the user back
+to your app afterwards.
+
+## What the policy actually enforces
+
+The token isn't a bearer token for "uploading" — it authorizes one narrowly
+described request, verified server-side before commit:
+
+- **Signature first.** The policy is HMAC-signed; one flipped character and the
+  request dies with `403` and nothing written.
+- **Every condition is checked** — bucket, exact key (or prefix), content type,
+  expiry. It fails closed: any submitted form field *not* covered by a policy
+  condition is rejected outright.
+- **Size is enforced on the wire.** The `content-length-range` is applied to the
+  actual streamed bytes, not a client-declared header. And if you forget to set
+  one, OpenBucket injects a default capped at the server's `maxObjectSizeMb`
+  limit — a minted token can never authorize more than the server allows.
+- **Bucket policies still apply.** An explicit `Deny` on the bucket beats a valid
+  token.
+
+One honest caveat: `createPresignedPost` signs with the root credential, so treat
+minted tokens like the capability grants they are — short `expiresIn`, tight
+conditions, and mint them from an authenticated endpoint only.
+
+## CORS — often you need none
+
+If you embed OpenBucket in the same NestJS app that serves your frontend (the
+setup from the last post), the browser POSTs to `/storage/avatars` on the **same
+origin** — CORS never enters the picture. This is the smoothest path, and worth
+preserving with a reverse-proxy route even when your SPA is hosted separately.
+
+When the store genuinely lives on another origin, S3 attaches CORS rules to the
+*bucket*, and OpenBucket answers the browser's unsigned `OPTIONS` preflight from
+those stored rules. Set them with any S3 client:
+
+```ts title="configure-cors.ts"
+import { S3Client, PutBucketCorsCommand } from '@aws-sdk/client-s3';
+
+await s3.send(
+  new PutBucketCorsCommand({
+    Bucket: 'avatars',
+    CORSConfiguration: {
+      CORSRules: [
+        {
+          AllowedOrigins: ['https://app.example.com'],
+          AllowedMethods: ['POST'],
+          AllowedHeaders: ['*'],
+          MaxAgeSeconds: 3600,
+        },
+      ],
+    },
+  }),
+);
+```
+
+…or click it together in the admin console's per-bucket **CORS** editor. A nice
+security detail: a preflight for a missing bucket, a bucket with no CORS config,
+and a bucket whose rules don't match all return the same opaque `403`, so
+anonymous preflights can't be used to enumerate bucket names. The supported
+surface is listed in the [S3 compatibility matrix](/docs/reference/s3-compatibility).
+
+## Step 3 — Read it back
+
+Same rule as always: store the stable `{ bucket, key }` in your database, never a
+signed URL. When you serve the file, mint a fresh presigned GET:
+
+```ts
+const url = this.ob.presignGetUrl('avatars', key, {
+  baseUrl: 'http://localhost:3000',
+  expiresIn: 3600, // 1 hour
+});
+```
+
+And if your server needs to *react* to an upload it never saw — create the DB
+row, kick off a thumbnail job — presigned POST uploads emit the same in-process
+`@OnObjectCreated()` events and webhooks as any other write. That's the
+[events guide](/docs/guides/events-and-webhooks).
+
+## When to use which upload path
+
+- **Through your API** (multer engine or `uploadFrom`) — when you want to inspect
+  or transform bytes inline, or the files are small. See
+  [file uploads](/docs/guides/file-uploads).
+- **Presigned POST** — when files are big or frequent enough that relaying them
+  is wasted work, and validation by content type + size range is enough.
+
+OpenBucket is pre-1.0 and single-node by design — the point isn't infinite scale,
+it's that direct-to-store uploads keep your app's event loop free even on one
+node, and the exact same code works against your laptop and your server.
+
+---
+
+If you ship this and shave a hop off your upload path, consider dropping a star
+on [GitHub](https://github.com/ProjectBay/openbucket) — it's the main way people
+discover self-hosted tools. And if your presigned-POST setup does something
+unusual (huge files? kiosk devices?), we'd love to compare notes in
+[Discussions](https://github.com/ProjectBay/openbucket/discussions).

--- a/apps/docs/blog/2026-07-29-openbucket-vs-minio.md
+++ b/apps/docs/blog/2026-07-29-openbucket-vs-minio.md
@@ -1,0 +1,174 @@
+---
+slug: openbucket-vs-minio
+title: 'OpenBucket vs MinIO: which self-hosted S3 for your project?'
+description: An honest decision guide for choosing between OpenBucket and MinIO — one question, a few real-world scenarios, and a clear answer for each.
+authors: [openbucket]
+tags: [comparison, minio, s3, self-hosted, object-storage]
+date: 2026-07-29
+draft: true
+keywords:
+  [
+    openbucket vs minio,
+    minio alternative,
+    self-hosted s3 server,
+    lightweight minio alternative,
+    s3 compatible storage self-hosted,
+    minio for local development,
+  ]
+---
+
+You've decided to self-host your object storage. Good — now you're staring at
+two S3-compatible options that look, from a distance, like they do the same
+thing. They don't. MinIO and OpenBucket sit at opposite ends of the self-hosted
+S3 spectrum, and picking the wrong end means either operating a distributed
+system you didn't need or outgrowing a single node you shouldn't have started
+on.
+
+The good news: the decision usually takes one question, not a feature-matrix
+staring contest. This post is the narrative version of that decision — for the
+detailed side-by-side, see the
+[docs comparison](/docs/comparisons/vs-minio). And yes, we're the OpenBucket
+team, so read accordingly — but you'll notice we send about half of you to
+MinIO. That's the point.
+
+<!-- truncate -->
+
+## The one question that decides it
+
+**Are you building an application that needs file storage, or are you operating
+storage as infrastructure for an organization?**
+
+That's it. Almost every scenario resolves from there.
+
+MinIO is a **storage tier**. It's a distributed Go system: erasure coding
+across nodes and drives, high availability, capacity that scales horizontally
+into petabytes. It's built to be the storage layer that many teams and services
+stand on — and it comes with the operational footprint that implies: a cluster
+(or at least a dedicated server) to provision, monitor, upgrade, and rebalance.
+
+OpenBucket is a **file backend for your app**. It's a single Node.js process
+over SQLite and the local filesystem — deliberately single-node, no clustering,
+no quorum, nothing to rebalance. It comes in two shapes: one small container you
+`docker run`, or an npm package (`@openbucket/nestjs`) that mounts a complete
+S3 endpoint, admin API, and admin console *inside your NestJS process*, under a
+path prefix. Your app and its object store become one deployable unit.
+
+These aren't two implementations of the same idea. They're different ideas that
+happen to speak the same wire protocol.
+
+## What MinIO does that OpenBucket doesn't
+
+Let's be plain about it, because this is where you should stop reading and go
+use MinIO if it describes you:
+
+- **Multi-node durability and high availability.** MinIO erasure-codes data
+  across drives and nodes and keeps serving through failures. OpenBucket is a
+  single point of failure for availability — if the node is down, your store is
+  down until it's back. There is no failover.
+- **Horizontal scale.** MinIO grows by adding nodes. OpenBucket grows by
+  getting a bigger disk, and its metadata lives in one SQLite database. Tens of
+  terabytes with high-concurrency multi-tenant traffic is not its lane.
+- **Storage as shared, polyglot infrastructure.** If five teams in three
+  languages need a common S3 endpoint — an S3 gateway for a data platform, a
+  backing store for your ML pipeline — a standalone cluster is the right shape.
+  An embeddable Node module is not.
+- **Years of production hardening at fleet scale.** OpenBucket is pre-1.0. The
+  S3 surface is feature-complete and conformance-tested, and a security audit
+  has been completed and remediated — but MinIO's maturity at scale is real and
+  we won't pretend otherwise.
+
+If you nodded at any of those, the honest recommendation is MinIO (or a managed
+service like AWS S3 or Cloudflare R2). Nothing below changes that.
+
+## What OpenBucket does that MinIO doesn't
+
+The flip side is just as concrete:
+
+- **It runs inside your application.** `npm install @openbucket/nestjs`, one
+  `forRoot()` call, and your NestJS app has an S3 endpoint at
+  `/storage`, an admin console at `/storage/admin`, and an in-process service
+  for uploads and presigned URLs — no second service, no container in local
+  dev, no docker-compose file for CI. MinIO is always a separate server.
+- **An app-layer file pipeline.** Because OpenBucket lives in the request
+  path, it can do things a remote store fundamentally can't: a one-line
+  [multer storage engine](/docs/guides/file-uploads) that streams uploads
+  straight into the store, in-process `@OnObjectCreated()` events,
+  [presigned browser POST](/docs/guides/sharing-files) helpers, and
+  [on-the-fly image transforms](/docs/guides/image-transforms)
+  (`?w=&h=&format=webp`) on GET. With MinIO, all of that is code you write
+  around a client SDK.
+- **Batteries-included admin, MIT-licensed.** The bundled Angular console —
+  bucket browser, object preview, access keys, usage analytics, audit log,
+  backup and replication management — ships under the same MIT license as
+  everything else.
+- **One process, one volume.** The entire ops story is a container, a bind
+  mount, and a backup schedule.
+
+On licensing: OpenBucket is **MIT**, MinIO's server is **AGPLv3**. For plenty
+of deployments AGPL is a non-issue, but if you're embedding storage into a
+proprietary product, it's a conversation to have with your team before you're
+committed — with MIT there's no conversation to have.
+
+## Scenarios, called plainly
+
+**A side project or homelab service.** OpenBucket. One container next to your
+app, or no container at all if it's NestJS. A MinIO deployment here is
+infrastructure for the sake of infrastructure.
+
+**An internal tool that stores attachments.** OpenBucket. Single node with
+[scheduled backups](/docs/guides/backup-and-restore) is an appropriate amount
+of durability for this data, and the admin console means you can actually see
+what's in there.
+
+**A SaaS on one VPS.** OpenBucket — with the caveat that you should turn on
+[async replication](/docs/guides/replication-and-tiering) to real S3, R2, or
+B2, so a dead disk costs you availability, not data. That's the honest
+durability story for anything customer-facing on one box: atomic writes,
+per-object SHA-256 verification, a bit-rot scrubber, and a second copy off the
+machine. It is a durable replica, not automatic HA.
+
+**S3 in local dev and CI.** OpenBucket, and this one isn't close if you're on
+Node: the same engine runs as an npm dependency on your laptop, in CI, and in
+production. No service to spin up, no port to wire, dev/prod parity for free.
+
+**Multi-node durability, or data you cannot lose measured in nines.** MinIO,
+or a hyperscaler. OpenBucket's durability is as good as your disk, your
+backups, and your replica — all of which *you* operate. We document exactly
+[how the bytes are protected](/docs/concepts/durability); we do not offer a
+durability SLA.
+
+**Petabytes, or an S3 gateway for a data platform.** MinIO. This is precisely
+what it's built for, and precisely what OpenBucket is designed not to be.
+
+## Picking "wrong" is cheap
+
+Here's the part that should lower the stakes: both systems speak the S3 wire
+protocol, and your application code talks to it through a standard SDK. If you
+start on OpenBucket and genuinely outgrow one node, your `S3Client` config
+changes and your code doesn't. OpenBucket is
+[verified against the AWS SDK, the `aws` CLI, MinIO's `mc`, and `s3cmd`](/docs/reference/s3-compatibility)
+in its conformance suite.
+
+The two even compose: OpenBucket can
+[replicate and tier cold objects to a MinIO cluster](/docs/guides/replication-and-tiering)
+as its external target — your app keeps its embedded store and app-layer
+pipeline, while the org's storage tier holds the durable copy.
+
+## The honest bottom line
+
+Choose **MinIO** when you're operating storage: multi-node HA, big scale,
+shared infrastructure. Choose **OpenBucket** when you're building an app: one
+node, one volume, an admin console in the box, and — if you're on NestJS — a
+whole object store that installs like a library. If you're still unsure which
+side you're on, [Is OpenBucket for you?](/docs/is-openbucket-for-you) exists to
+talk you out of a bad fit, and the
+[full comparison matrix](/docs/comparisons/vs-minio) has the line-by-line
+details.
+
+---
+
+If this helped you decide — in either direction — a ⭐ on
+[GitHub](https://github.com/ProjectBay/openbucket) is how more people find
+guides that tell them when *not* to use the product. Disagree with a call we
+made here? We'd honestly like to hear it in
+[Discussions](https://github.com/ProjectBay/openbucket/discussions).

--- a/apps/docs/blog/2026-08-05-sqlite-and-the-filesystem-object-store.md
+++ b/apps/docs/blog/2026-08-05-sqlite-and-the-filesystem-object-store.md
@@ -1,0 +1,173 @@
+---
+slug: sqlite-and-the-filesystem-object-store
+title: SQLite + the filesystem is a perfectly good object store (for one node)
+description: Why OpenBucket stores metadata in SQLite and blobs on the local filesystem — the atomic write path, the concurrency model, and where the ceiling really is.
+authors: [openbucket]
+tags: [architecture, sqlite, s3, self-hosted, durability, deep-dive]
+date: 2026-08-05
+keywords:
+  [
+    sqlite object storage,
+    self-hosted s3 compatible,
+    single node object store,
+    minio alternative single node,
+    atomic file writes fsync rename,
+    object storage architecture,
+    sqlite metadata store,
+  ]
+draft: true
+---
+
+OpenBucket stores object metadata in a single SQLite file and object bytes as
+plain files on the local filesystem. When people hear that, the reaction tends to
+split: half say "obviously, that's all most apps need," and the other half start
+listing the ways it will fall over. Both halves are onto something.
+
+This post is the honest version of the argument. Not "SQLite scales further than
+you think" (true, but not the point), and not "you probably won't lose data"
+(never say that). The claim is narrower: for a single node, a transactional
+metadata store plus atomic filesystem writes is not a budget imitation of a
+distributed object store — it's a different design with different trade-offs, and
+for a large class of applications those trade-offs are the right ones. Here's what
+the design actually looks like, mechanism by mechanism, including where the
+ceiling is.
+
+<!-- truncate -->
+
+## The split: SQLite decides, the filesystem holds
+
+Every object in OpenBucket lives in two places:
+
+- **SQLite** holds the truth: one row per `(bucket, key)` with size, ETag, content
+  type, user metadata, tags, lock state — and a stored SHA-256 of the plaintext
+  bytes. Version history, multipart bookkeeping, access keys, lifecycle cursors,
+  and the replication outbox are all rows in the same database.
+- **The filesystem** holds the bytes: `DATA_DIR/blobs/<bucket>/<encoded-key>`,
+  with S3 keys percent-encoded per path segment so arbitrary UTF-8 keys can't
+  escape the tree or collide with filesystem quirks. Prior versions of a key sit
+  next to it in a `<key>.v/<versionId>` directory.
+
+The database is authoritative; the blob file is just the payload the row points
+at. A `GET` never trusts the filesystem to know what exists — it asks SQLite,
+then opens the file. That one rule is what makes crash recovery tractable, as
+we'll see. (Full layout: [storage layout](/docs/concepts/storage-layout).)
+
+## How a write actually lands
+
+The core write path, straight from the code:
+
+1. Stream the body into `DATA_DIR/tmp/put-<uuid>`, opened with `O_EXCL` so two
+   writers can never share a staging file. MD5 (the future ETag) and SHA-256 are
+   computed **on the same pass**, over plaintext, before any at-rest encryption.
+2. `fsync` the temp file — the bytes are on the platter, not in the page cache.
+3. `rename(2)` it to its final path. On one filesystem, rename is atomic: readers
+   see the old file or the new one, never a torn half.
+4. `fsync` the parent directory, so the rename itself survives power loss.
+5. Commit the metadata row — pointer update, the version row if the bucket is
+   versioned, and the replication intent — in **one SQLite transaction**.
+
+The transaction commit is the linearization point. A crash before step 5 leaves
+at most an orphan blob with no row pointing at it; a startup recovery scan
+reconciles that (and cleans abandoned multipart staging) without ever guessing.
+Overwrites get extra care: the current blob is hard-linked aside as a zero-copy
+backup before the swap, restored if the commit fails, discarded if it succeeds.
+A failed overwrite is a no-op, not a corrupted key.
+
+SQLite itself runs in WAL mode with `synchronous = FULL`, so a committed
+transaction is fsync'd before the write returns. None of this is exotic — it's
+the same staging-plus-rename discipline Maildir and package managers have used
+for decades. The point is that on a single filesystem, *the primitives for
+atomic, durable writes already exist*. You don't need a consensus protocol to
+get them; you need to actually call `fsync` in the right places.
+
+## What SQLite buys that a directory of JSON files doesn't
+
+The metadata store could have been flat files too — plenty of home-grown blob
+stores do exactly that, and it's where they go wrong. A real database buys:
+
+- **Multi-row atomicity.** A versioned PUT touches the pointer row, inserts a
+  version row, and enqueues a replication intent. One transaction: all of it
+  commits or none of it does. The replication outbox can never record a write
+  that didn't happen, and a committed write can never miss its outbox entry.
+- **Real queries.** `ListObjectsV2` is an indexed range scan with a computed
+  upper bound — not a `LIKE 'prefix%'` that defeats the index, and not a
+  `readdir` walk that falls over at a million keys.
+- **One-file operations.** The entire metadata plane is `openbucket.db`. Backups,
+  migrations (forward-only, run at boot), and "copy the volume somewhere safe"
+  all stay boring.
+- **Zero operational surface.** No connection pool, no server to patch, no
+  credentials to rotate for a database nobody else connects to.
+
+## "But SQLite has a single writer"
+
+Yes — and that's fine, because there is exactly one process. OpenBucket's
+[concurrency model](/docs/whitepaper/04-streaming-and-concurrency) is the
+event loop, not threads. Writes to SQLite serialize; WAL readers proceed in
+parallel and don't block behind writers. Blob I/O runs on libuv's thread pool,
+so concurrent uploads to *different* keys stream in parallel with no shared
+state — distinct temp files, distinct rename targets, distinct rows.
+
+The interesting cases are the racy ones, and they resolve with POSIX semantics
+rather than locks. Two clients PUT the same key concurrently? Both stage to
+their own temp files; both renames are atomic; a per-key mutex in the writer
+serializes the metadata commits, and the last committed transaction wins the
+ETag — which is exactly S3's last-writer-wins contract. A `GET` racing a
+`DELETE`? The reader already holds an open file descriptor; `unlink` removes the
+directory entry but the inode survives until the descriptor closes, so the read
+drains cleanly and the *next* one gets a 404. No tombstones, no reference
+counting — the kernel already implements this.
+
+## Where the ceiling genuinely is
+
+Now the concessions, because they're real and they're the point:
+
+- **This is a single point of failure for availability.** No clustering, no
+  quorum, no failover. If the node is down, your store is down until it's back.
+- **Scale is vertical.** One machine's disk, one metadata database. Tens of
+  terabytes and high-concurrency multi-tenant workloads will outgrow it, and
+  there is no shard button.
+- **Durability is your disk and your fsync.** OpenBucket does its part of the
+  contract; if the hardware lies about flushes, no software fixes that.
+
+If any of those are disqualifying, use AWS S3, R2, or a MinIO cluster — the
+[fit guide](/docs/is-openbucket-for-you) says this in the first paragraph, not
+the footnotes.
+
+What the durability features change is the *risk calculus*, not the availability
+math. [Async replication](/docs/guides/replication-and-tiering) mirrors every
+committed PUT and DELETE to a real S3-compatible target (S3, R2, B2, MinIO)
+through that transactional outbox — surviving remote outages via retry and
+resuming on boot. Every full `GET` re-hashes the stream against the stored
+SHA-256 and refuses to serve corrupt bytes; an opt-in background scrubber hunts
+bit-rot proactively and, when a replica exists, repairs a corrupt blob from the
+known-good remote copy. [Scheduled backups](/docs/guides/backup-and-restore)
+snapshot the whole instance — version history, encryption config, policies —
+to a restorable archive, optionally pushed off-box. That's "one node, plus a
+durable copy elsewhere, plus continuous integrity checking." It is not HA, and
+we won't call it HA. For a lot of workloads — internal tools, single-region
+SaaS, self-hosted products, edge boxes, air-gapped deployments — it's an honest
+match for what the data actually needs. (The full mechanism-by-mechanism story:
+[durability](/docs/concepts/durability).)
+
+## Right-sized, not down-sized
+
+The distributed alternative has costs people wave away: a cluster to operate,
+erasure-coding parameters to understand, upgrade choreography, and a failure
+surface where the storage system itself becomes the most complex thing you run.
+Paying those costs makes sense when you need what they buy. Paying them by
+default — for an app whose entire dataset fits on one NVMe drive — is cargo
+culting, and "we might need to scale someday" is how you end up operating a
+distributed system for a workload SQLite could have handled from a laptop.
+
+One process, one database file, one directory tree, and a short list of rules
+that make writes atomic. You can read the whole persistence design in an
+afternoon and audit the write path in an hour. For one node, that's not the
+compromise. That's the feature.
+
+---
+
+If this kind of design writing is useful, a ⭐ on
+[GitHub](https://github.com/ProjectBay/openbucket) is the best way to signal we
+should do more of it. Spotted a hole in the argument? We'd genuinely like to
+hear it — open a thread in
+[Discussions](https://github.com/ProjectBay/openbucket/discussions).

--- a/apps/docs/blog/2026-08-12-point-your-s3-sdk-at-localhost.md
+++ b/apps/docs/blog/2026-08-12-point-your-s3-sdk-at-localhost.md
@@ -1,0 +1,226 @@
+---
+slug: point-your-s3-sdk-at-localhost
+title: 'Keep your S3 SDK, swap the endpoint: local-dev object storage without AWS'
+description: Point @aws-sdk/client-s3 at a local Docker container instead of AWS — change the endpoint, set forcePathStyle, and your existing S3 code keeps working.
+authors: [openbucket]
+tags: [s3, local-development, docker, aws-sdk, self-hosted]
+date: 2026-08-12
+keywords:
+  [
+    s3 compatible local development,
+    aws sdk local s3 endpoint,
+    minio alternative local dev,
+    s3 emulator docker,
+    forcePathStyle localhost,
+    local s3 docker compose,
+    self-hosted s3 for developers,
+  ]
+draft: true
+---
+
+Your app already talks S3. The `@aws-sdk/client-s3` calls are written, tested,
+and shipping to production. The annoying part is everything *around* local
+development: shared dev buckets that teammates trample, IAM credentials on
+laptops, tests that hit the network, and a cloud bill for uploading `test.png`
+four hundred times.
+
+Here's the whole pitch of this post: you don't have to change your S3 code to
+fix that. OpenBucket speaks the S3 wire protocol — SigV4 auth, presigned URLs,
+multipart uploads, versioning, XML errors — so your existing SDK code keeps
+working. You change the **endpoint**, the **credentials**, and set
+**path-style addressing**. That's the entire migration.
+
+<!-- truncate -->
+
+## Step 1 — Run the store (one container)
+
+OpenBucket ships as a single multi-arch image on GHCR:
+`ghcr.io/projectbay/openbucket`. It refuses to boot with weak or missing
+secrets, so you pass a handful of env vars. For pure local dev, `ADMIN_PASSWORD`
+is the shortcut — OpenBucket argon2id-hashes it on first boot and never stores
+the plaintext (for hardened setups you'd pass a pre-computed
+`ADMIN_PASSWORD_HASH` instead):
+
+```bash
+docker run --rm -p 9000:9000 -v openbucket-data:/data \
+  -e DATA_DIR=/data \
+  -e ADMIN_PASSWORD='local-dev-password' \
+  -e JWT_SECRET="$(openssl rand -hex 32)" \
+  -e ROOT_ACCESS_KEY_ID='AKIALOCALDEV0000000' \
+  -e ROOT_SECRET_ACCESS_KEY='local-dev-secret-key-at-least-32-chars!!' \
+  ghcr.io/projectbay/openbucket:0.1.0-alpha.20
+```
+
+The constraints, if you pick your own values: `ROOT_ACCESS_KEY_ID` is 16–32
+uppercase alphanumerics, and `JWT_SECRET` / `ROOT_SECRET_ACCESS_KEY` are 32+
+characters.
+
+Prefer compose? The repo ships a ready-made
+[`examples/docker-standalone`](https://github.com/ProjectBay/openbucket/tree/main/examples/docker-standalone)
+with a named volume and a healthcheck — the core of it:
+
+```yaml title="docker-compose.yml"
+services:
+  openbucket:
+    image: ghcr.io/projectbay/openbucket:0.1.0-alpha.20
+    restart: unless-stopped
+    ports:
+      - '9000:9000'
+    env_file:
+      - .env
+    environment:
+      DATA_DIR: /data
+    volumes:
+      - openbucket-data:/data
+
+volumes:
+  openbucket-data:
+```
+
+Either way, everything now lives on **http://localhost:9000**: the S3 API at
+the root (path-style), the admin console at `/admin`, and health probes at
+`/api/admin/health`. Full setup details are in the
+[Docker quickstart](/docs/getting-started/quickstart-docker).
+
+## Step 2 — The config diff
+
+This is the entire code change. If your `S3Client` config already comes from
+env vars, it's a **zero-code** change:
+
+```diff
+ import { S3Client } from '@aws-sdk/client-s3';
+
+ const s3 = new S3Client({
+-  region: 'eu-central-1',
++  endpoint: 'http://localhost:9000',
++  region: 'us-east-1',
++  forcePathStyle: true,
++  credentials: {
++    accessKeyId: 'AKIALOCALDEV0000000',
++    secretAccessKey: 'local-dev-secret-key-at-least-32-chars!!',
++  },
+ });
+```
+
+Three things worth knowing:
+
+- **`forcePathStyle: true` is required.** OpenBucket addresses buckets as
+  `http://localhost:9000/my-bucket/key`, never as a
+  `my-bucket.localhost` subdomain. Virtual-host addressing is not supported —
+  which is fine, because subdomains and localhost never got along anyway.
+- **`region: 'us-east-1'`** matches the default `OPENBUCKET_REGION` the store
+  reports. If you override one, override both — SigV4 signatures embed the
+  region.
+- **The credentials are the root key pair** you set via env vars — no IAM, no
+  session tokens, nothing to provision.
+
+This isn't a docs-only claim: it is byte-for-byte how OpenBucket's own
+conformance suite configures `@aws-sdk/client-s3` against a freshly booted
+container before round-tripping objects through it.
+
+## Step 3 — A put / get / presign roundtrip
+
+Your existing commands work unchanged. A quick smoke test:
+
+```ts
+import {
+  CreateBucketCommand,
+  GetObjectCommand,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+
+await s3.send(new CreateBucketCommand({ Bucket: 'uploads' }));
+
+await s3.send(
+  new PutObjectCommand({
+    Bucket: 'uploads',
+    Key: 'hello.txt',
+    Body: 'Hello from localhost',
+    ContentType: 'text/plain',
+  }),
+);
+
+const got = await s3.send(new GetObjectCommand({ Bucket: 'uploads', Key: 'hello.txt' }));
+console.log(await got.Body!.transformToString()); // "Hello from localhost"
+
+// Presigned URLs work too — SigV4 query auth, verified server-side:
+const url = await getSignedUrl(
+  s3,
+  new GetObjectCommand({ Bucket: 'uploads', Key: 'hello.txt' }),
+  { expiresIn: 900 },
+);
+```
+
+Paste that URL into a browser or `curl` it — the store verifies the signature
+and expiry exactly like AWS does. Streaming PUT/GET, multipart uploads, range
+reads, tagging, and bucket versioning (including `?versionId` reads) behave the
+same way; the [S3 compatibility reference](/docs/reference/s3-compatibility)
+lists the full surface.
+
+## Not just the JavaScript SDK
+
+Anything that speaks S3 with path-style addressing works. OpenBucket's
+conformance matrix runs these clients in CI alongside the JS SDK:
+
+```bash
+# AWS CLI
+aws --endpoint-url http://localhost:9000 s3 mb s3://my-bucket
+aws --endpoint-url http://localhost:9000 s3 cp ./photo.jpg s3://my-bucket/photo.jpg
+
+# MinIO client (mc)
+mc alias set local http://localhost:9000 "$ACCESS_KEY" "$SECRET_KEY" --api S3v4
+mc cp ./photo.jpg local/my-bucket/
+
+# s3cmd works too — it's the third row of the same conformance matrix
+```
+
+If your stack is Python, Go, or Rust, the recipe is identical: endpoint,
+region, credentials, path-style. The wire protocol is the contract.
+
+## The part where it stops being an emulator
+
+Here's the difference from a throwaway mock: OpenBucket isn't a fake S3 that
+you discard on deploy. It's a real, persistent object store — SQLite for
+metadata, the local filesystem for blobs — that you can also run as your
+production storage on a single node, or embed straight into a NestJS app as an
+npm package. Same engine, same data, laptop to server.
+
+And because it's a full store rather than a stub, local dev picks up things a
+mock never gives you:
+
+- **An admin console at `/admin`** — sign in with `admin` and your password to
+  browse buckets, preview objects inline, mint share links, and manage access
+  keys. No more `aws s3 ls` archaeology to find out what your test suite wrote.
+- **Real S3 semantics** — versioning, lifecycle rules, CORS, bucket policies,
+  and object lock are all there to develop against, not discover in staging.
+- **Presigned uploads and downloads** that behave like production, so your
+  browser-upload flow is testable offline.
+
+## The honest caveats
+
+OpenBucket is **pre-1.0** and under active development — the S3 surface and
+admin console are feature-complete and tested, but APIs may still move before
+1.0. It's also **single-node by design**: one process, SQLite, local disk.
+That's exactly right for local dev, CI, and self-hosted apps of moderate scale;
+it is not a distributed storage cluster, and we won't pretend otherwise. For
+multi-node or petabyte territory, the
+[OpenBucket vs MinIO](/docs/comparisons/vs-minio) comparison and
+[Is OpenBucket for you?](/docs/is-openbucket-for-you) lay out where the line is.
+
+## Try the swap
+
+The whole experiment costs you one `docker run` and a three-line config diff —
+and it's just as quick to undo. Start with the
+[Docker quickstart](/docs/getting-started/quickstart-docker), and check the
+[configuration reference](/docs/reference/configuration) when you outgrow the
+defaults.
+
+---
+
+If OpenBucket earns a permanent slot in your `docker-compose.yml`, consider
+dropping a ⭐ on [GitHub](https://github.com/ProjectBay/openbucket) — stars are
+how small self-hosted projects get found. Hit a compatibility edge with your
+SDK of choice? Tell us in
+[Discussions](https://github.com/ProjectBay/openbucket/discussions); the
+conformance matrix grows from exactly those reports.

--- a/apps/docs/blog/2026-08-19-self-hosted-image-transforms.md
+++ b/apps/docs/blog/2026-08-19-self-hosted-image-transforms.md
@@ -1,0 +1,207 @@
+---
+slug: self-hosted-image-transforms
+title: 'Build your own Cloudinary-lite: on-the-fly image transforms on GET'
+description: Store one original, request any variant with query params. Self-hosted image resizing with WebP/AVIF, srcset, caching, and DoS bounds — no per-image fees.
+authors: [openbucket]
+tags: [images, tutorial, performance, self-hosted, nestjs]
+date: 2026-08-19
+draft: true
+keywords:
+  [
+    self-hosted image resizing,
+    cloudinary alternative self-hosted,
+    on the fly image resize nodejs,
+    nestjs image optimization,
+    self-hosted image cdn,
+    webp avif conversion server,
+  ]
+---
+
+Image pipelines have a way of growing sideways. You start with one upload, then
+the design needs a 200px thumbnail, then the landing page wants a 1600px hero,
+then someone asks why you're shipping 2 MB JPEGs to phones that speak AVIF. The
+usual fixes are a paid transform service (Cloudinary, imgix) or yet another
+container to babysit (Thumbor, imgproxy).
+
+OpenBucket bakes this into the object store you already have: **store one
+original, and every variant is just query params on the GET URL**. `?w=400&format=webp`
+resizes and re-encodes on the fly, caches the result forever, and serves the next
+request from disk. In this post we'll upload one image and get responsive
+`srcset` variants, modern formats, and crop modes out of it — then look honestly
+at what this is *not*.
+
+<!-- truncate -->
+
+## One original, many URLs
+
+Transforms run on the normal S3 GET route. Any authorized object GET becomes a
+transform request when at least one of `w`, `h`, or `format` is present:
+
+```
+GET /assets/hero.jpg?w=400&format=webp
+```
+
+The full grammar is five params:
+
+| Param    | Meaning                    | Values                                          | Default         |
+| -------- | -------------------------- | ----------------------------------------------- | --------------- |
+| `w`      | Target width in pixels     | `1 … 4096`                                      | —               |
+| `h`      | Target height in pixels    | `1 … 4096`                                      | —               |
+| `fit`    | How to fit within `w`/`h`  | `cover`, `contain`, `fill`, `inside`, `outside` | `cover`         |
+| `format` | Re-encode to this format   | `webp`, `jpeg`, `png`, `avif`                   | native format   |
+| `q`      | Encode quality             | `1 … 100`                                       | `80`            |
+
+Two useful edge behaviors: omit `w` and `h` and the image keeps its dimensions
+but re-encodes (a plain `?format=webp` is a format conversion), and **upscaling
+is disabled** — a source smaller than the requested size comes back at its own
+size, never enlarged. EXIF orientation is honored, so portrait phone photos
+arrive the right way up.
+
+## Step 1 — Upload the original
+
+OpenBucket speaks S3, so any client works. With the AWS CLI pointed at your
+instance:
+
+```bash
+aws s3 cp ./hero.jpg s3://assets/hero.jpg \
+  --endpoint-url http://localhost:3000/storage
+```
+
+Or, if you followed the [NestJS uploads tutorial](/docs/guides/file-uploads),
+the multer interceptor already put it there. Either way: that's the last resize
+decision you make at upload time. Store the biggest original you have.
+
+## Step 2 — Responsive images with `srcset`
+
+Because every variant is just a URL, `srcset` needs no build step and no
+pre-generated renditions:
+
+```html
+<img
+  src="/storage/assets/hero.jpg?w=800&format=webp"
+  srcset="
+    /storage/assets/hero.jpg?w=400&format=webp   400w,
+    /storage/assets/hero.jpg?w=800&format=webp   800w,
+    /storage/assets/hero.jpg?w=1600&format=webp 1600w
+  "
+  sizes="(max-width: 600px) 100vw, 800px"
+  alt="Hero"
+/>
+```
+
+The browser picks a width; OpenBucket renders that width once and caches it.
+Add a retina thumbnail (`?w=200&h=200&fit=cover` — a centered square crop) or a
+letterboxed preview (`fit=contain`) the same way. `fit=inside` is the "shrink to
+fit, never crop" mode you want for user-supplied content of unknown aspect
+ratio.
+
+## Step 3 — Modern formats
+
+Output formats are `webp`, `jpeg`, `png`, and `avif`. Decodable **source**
+formats are JPEG, PNG, WebP, AVIF, GIF, and TIFF — anything else, including SVG,
+passes straight through to the normal GET untouched (SVG is deliberately
+excluded as an active-content surface). So:
+
+```
+?format=avif&q=60      # same dimensions, AVIF at quality 60
+?w=1200&format=webp    # 1200px-wide WebP
+```
+
+One honest caveat: there's no `Accept`-header content negotiation — you pick
+the format in the URL. For most apps that's fine (ship AVIF or WebP with a
+`<picture>` fallback); it's one of the places a dedicated image CDN does more.
+
+## What happens on the second request
+
+The first request decodes, resizes, and re-encodes with sharp. Everything after
+that is a disk read, because each derivative is **content-addressed**: the cache
+key is a hash of the source object's ETag plus the exact transform params, and
+the files live under `DATA_DIR/derivatives/`.
+
+That one design choice buys three things:
+
+- **Immutable caching.** The response carries the derivative's content hash as
+  its `ETag` and `Cache-Control: public, max-age=31536000, immutable`. A browser
+  revalidating with `If-None-Match` gets a `304` with zero decode work — and any
+  CDN or reverse-proxy cache in front can hold the response indefinitely.
+- **Invalidation for free.** Overwrite the source object and its ETag changes,
+  so every derivative URL naturally resolves to a fresh render. Orphaned old
+  derivatives are reclaimed by a background GC tick against a size cap
+  (`DERIVATIVE_CACHE_MAX_BYTES`, default 5 GiB). No purge API to call, no
+  cache-busting query hacks.
+- **No stampedes.** A cold-cache burst is collapsed by single-flight: one
+  decode, one write, every concurrent requester gets the shared result.
+
+## The presigned-URL gotcha
+
+A presigned URL signs its **entire query string**. Tack `?w=400` onto a minted
+presigned GET and you've broken the signature — the request is rejected. To use
+transforms you either serve from a **public-read bucket** (attach an anonymous
+`s3:GetObject` bucket policy, then plain `<img src>` URLs work — see
+[Sharing files](/docs/guides/sharing-files)) or issue a fully SigV4-signed
+request with the transform params baked into what's signed. For `<img>` tags on
+a public site, the public bucket is the usual answer.
+
+Authorization itself is unchanged: a transform GET runs through exactly the same
+`s3:GetObject` checks as a plain GET. No new access path.
+
+## The part that keeps you off the front page of HN
+
+An open resize endpoint is a classic DoS target — "please decode this
+30,000×30,000 PNG at quality 100, a thousand times". OpenBucket's defense is
+layered, and every knob is a bound:
+
+| Env var                              | Default             | What it bounds                          |
+| ------------------------------------ | ------------------- | --------------------------------------- |
+| `IMAGE_TRANSFORM_ENABLED`            | `true`              | Master switch                            |
+| `MAX_TRANSFORM_DIMENSION`            | `4096`              | Max `w`/`h`, enforced before any decode  |
+| `MAX_TRANSFORM_INPUT_BYTES`          | 50 MiB              | Refuses oversized sources pre-buffer     |
+| `IMAGE_TRANSFORM_LIMIT_INPUT_PIXELS` | 576,000,000         | Decompression bomb → `400`               |
+| `IMAGE_TRANSFORM_CONCURRENCY`        | `4`                 | Concurrent decodes; the rest queue       |
+| `DERIVATIVE_CACHE_MAX_BYTES`         | 5 GiB               | On-disk derivative cache cap             |
+
+Bad input — an out-of-range dimension, an unknown format, an undecodable file —
+is always an S3-style `400`, never a `500` or an OOM. The per-IP request
+throttle sits in front of all of it.
+
+## Where this sits next to Cloudinary, imgix, and Thumbor
+
+Being upfront: **OpenBucket is not a CDN.** Cloudinary and imgix run global edge
+networks, do `Accept`-based format negotiation, and offer far deeper transform
+DSLs (face detection, watermarks, smart crop). OpenBucket is a single-node,
+pre-1.0 store — your images render on your box, at your box's latency.
+
+What you get in exchange:
+
+- **Zero per-image, per-transform, per-bandwidth fees.** The pricing model is
+  "your disk".
+- **Data stays on your infrastructure** — no third party ever holds your
+  originals.
+- **No extra moving part.** Thumbor and imgproxy are good software, but they're
+  another service with its own config, auth story, and deploys. Here the
+  transform pipeline lives inside the object store (and, in the embedded case,
+  inside your NestJS app) you already run.
+
+For a public site, the pieces compose cleanly: the immutable, content-addressed
+responses are exactly what a CDN wants, so putting Cloudflare or any caching
+proxy in front gives you edge delivery while OpenBucket only ever renders each
+variant once. For an internal tool or a moderate-traffic app, the on-disk cache
+alone is plenty. If you're weighing the trade-offs, the
+[Is OpenBucket for you?](/docs/is-openbucket-for-you) guide is deliberately
+blunt about them.
+
+## Next steps
+
+- The full parameter and configuration reference:
+  [image transforms guide](/docs/guides/image-transforms)
+- Public buckets vs. presigned URLs: [sharing files](/docs/guides/sharing-files)
+- Getting images in: [file uploads](/docs/guides/file-uploads)
+- Every knob: [configuration reference](/docs/reference/configuration)
+
+---
+
+Built something with this — or hit a transform you wish existed? Tell us in
+[Discussions](https://github.com/ProjectBay/openbucket/discussions). And if
+"one original, infinite variants, zero invoices" is your kind of trade, a star
+on [GitHub](https://github.com/ProjectBay/openbucket) helps the project reach
+the next person shopping for a self-hosted Cloudinary alternative.

--- a/apps/docs/blog/2026-08-26-aws-signature-v4-from-scratch.md
+++ b/apps/docs/blog/2026-08-26-aws-signature-v4-from-scratch.md
@@ -1,0 +1,229 @@
+---
+slug: aws-signature-v4-from-scratch
+title: "AWS Signature V4 from scratch: what it actually takes to speak S3"
+description: What we learned implementing server-side SigV4 verification for an S3-compatible store — encoding traps, header folding, chunk signing, and more.
+authors: [openbucket]
+tags: [s3, sigv4, security, deep-dive, nodejs]
+date: 2026-08-26
+draft: true
+keywords:
+  [
+    aws signature v4 explained,
+    sigv4 canonical request,
+    implement sigv4 verification,
+    s3 compatible api authentication,
+    sigv4 presigned url verification,
+    aws chunked upload signing,
+  ]
+---
+
+Every request an AWS SDK sends to S3 carries an HMAC signature computed over a
+_canonical_ rendering of that request. Signing is the easy direction — the SDKs
+do it for you, and if you get a detail wrong you find out immediately. Building
+an S3-compatible server means doing the opposite: **verifying** signatures from
+every client in the wild, where each SDK, CLI, and hand-rolled signer gets a
+different detail wrong (or right, in a way your reconstruction has to match
+byte-for-byte). One stray space in a header value and the HMACs diverge with
+nothing but `SignatureDoesNotMatch` to debug from.
+
+We implemented SigV4 verification from scratch for OpenBucket's S3 endpoint —
+header signing, presigned URLs, POST policies, and chunked streaming uploads.
+This post walks the algorithm the way the verifier sees it, and collects the
+traps we actually hit, with pointers to how the code handles them.
+
+<!-- truncate -->
+
+## The algorithm in one paragraph
+
+SigV4 never transmits the secret key. The client builds a **canonical request**
+(a normalized text rendering of the method, path, query, headers, and payload
+hash), hashes it into a **string to sign**, derives a **signing key** from the
+secret through a chain of HMACs, and sends `hex(HMAC-SHA256(signingKey,
+stringToSign))` in the `Authorization` header. The server holds the same secret,
+rebuilds the exact same canonical request from the raw HTTP request, re-derives
+the key, and compares signatures. Symmetric — which means _every_ normalization
+rule is a place where the two sides can disagree.
+
+```text
+CanonicalRequest =
+  HTTPMethod \n
+  CanonicalURI \n
+  CanonicalQueryString \n
+  CanonicalHeaders \n
+  SignedHeaders \n
+  HashedPayload
+```
+
+## The canonical URI: encoding is where hope goes to die
+
+SigV4 mandates an AWS-flavored RFC 3986 encoding: only `A–Z a–z 0–9 - _ . ~`
+pass through, everything else is percent-encoded **per UTF-8 byte** with
+uppercase hex. `encodeURIComponent` is close but not equal (it leaves `!'()*`
+unescaped), so we wrote it out longhand:
+
+```ts
+// canonical-request.ts — byte-by-byte, uppercase hex, '/' preserved in paths
+for (const byte of Buffer.from(input, 'utf8')) {
+  // unreserved chars pass; '/' passes only when encodeSlash === false
+  out.push('%' + byte.toString(16).toUpperCase().padStart(2, '0'));
+}
+```
+
+Two traps hide here:
+
+1. **S3 single-encodes; most other AWS services double-encode.** For S3 the
+   canonical URI is the path with each segment encoded exactly once, slashes
+   preserved. Our verifier splits the path on `/`, encodes each segment, and
+   rejoins — never encoding the separators themselves.
+2. **Your framework already decoded the URL once.** Express hands you a decoded
+   path, so the verifier reconstructs the canonical form by re-encoding from
+   `req.originalUrl` rather than trusting the routed params. An object key
+   like `résumé (1).pdf` has to round-trip to `r%C3%A9sum%C3%A9%20%281%29.pdf`
+   — UTF-8 bytes, encoded space, encoded parens — or the hashes diverge.
+
+The query string gets its own normalization: split on `&`, decode each key and
+value, re-encode both with the strict encoder (slashes encoded this time), then
+sort **by key, and by value for duplicate keys**. Keys with no `=` become
+`key=` with an empty value — S3 subresources like `?versioning` are exactly
+this shape, so getting the empty-value case wrong breaks half the bucket API.
+
+## Canonical headers: lowercase, trim, fold
+
+Each signed header contributes one line: name lowercased, value trimmed, and
+**sequential internal whitespace collapsed to a single space**. Multi-value
+headers are joined with commas. The client tells you which headers it signed
+via the `SignedHeaders` list — and that list is itself part of the canonical
+request.
+
+Which raises an uncomfortable question: what if a client just… leaves headers
+out of the list? A signature that doesn't cover `host` isn't bound to your
+endpoint, and an unsigned `x-amz-*` header could be altered in flight without
+invalidating anything. AWS rejects such requests, and so do we — the verifier
+requires `host` in `SignedHeaders` and requires every `x-amz-*` header actually
+present on the wire to be signed. Every mainstream SDK already does this, so
+the check only bites forged or tampered requests.
+
+One more parsing landmine: the `Authorization` header's
+`Credential=…, SignedHeaders=…, Signature=…` directives are attacker-controlled
+key–value pairs. Ours parse into a null-prototype object against an explicit
+allowlist of those three names, so a crafted `__proto__=…` directive can't
+reach `Object.prototype`. There's a regression test that tries.
+
+## The payload hash — and the streaming rabbit hole
+
+The last canonical-request line is `x-amz-content-sha256`: either the hex
+SHA-256 of the body or one of several magic strings. Counterintuitively, **the
+verifier takes this value verbatim and never recomputes it over the body** —
+the header is itself in `SignedHeaders`, so a lie about the payload hash breaks
+the signature on its own. Recomputing would also force buffering a possibly
+multi-gigabyte PUT before authenticating it.
+
+The values OpenBucket accepts:
+
+- **A hex SHA-256** — classic signed payload.
+- **`UNSIGNED-PAYLOAD`** — the body isn't covered by the signature (standard
+  for presigned URLs, and common over TLS).
+- **`STREAMING-AWS4-HMAC-SHA256-PAYLOAD`** — aws-chunked signed streaming. The
+  header signature becomes a _seed_, and each body chunk carries its own
+  signature chaining from the previous one:
+
+```text
+chunkStringToSign =
+  AWS4-HMAC-SHA256-PAYLOAD \n
+  <amzDate> \n <credentialScope> \n
+  <previousSignature> \n
+  SHA256("") \n
+  SHA256(chunkData)
+```
+
+  The guard verifies the seed like any header signature, then stashes the
+  derived signing key so the chunk decoder can verify the rolling chain — the
+  final zero-length chunk signs the empty hash and closes it.
+- **`STREAMING-UNSIGNED-PAYLOAD-TRAILER`** — unsigned chunks with a trailing
+  checksum, the aws-cli v2 default.
+
+What it does **not** support: `STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER`,
+the signed-trailer variant. That one is rejected explicitly with an
+`InvalidArgument` naming the header, instead of a baffling signature mismatch —
+if you must fail, fail with a diagnosis.
+
+## Deriving the signing key
+
+The secret never signs anything directly. It's stretched through a dated,
+scoped HMAC chain:
+
+```ts
+// sigv4.verifier.ts
+const kDate = hmac(`AWS4${secretAccessKey}`, date); // e.g. '20260826'
+const kRegion = hmac(kDate, region);
+const kService = hmac(kRegion, service); // 's3'
+const kSigning = hmac(kService, 'aws4_request');
+```
+
+The scope (`date/region/service/aws4_request`) comes from the client's
+`Credential` and is signed into the string to sign, so you can't replay a
+signature across days, regions, or services. One derivation function is shared
+by all four verification paths — header, presigned, POST policy, and chunk
+chain — because two implementations of key derivation is how you get one subtle
+disagreement.
+
+Replay is further bounded by a clock check: `X-Amz-Date` must be within **±15
+minutes** of server time (AWS's window), or the request is rejected with
+`RequestTimeTooSkewed`. Our tests pin the boundary: ±14 minutes passes, ±16
+fails.
+
+Finally, the comparison itself: signatures are compared with
+`crypto.timingSafeEqual` over UTF-8 bytes, and an unknown access key returns
+the same generic `SignatureDoesNotMatch` as a wrong secret — no timing oracle
+on the signature, no existence oracle on key IDs.
+
+## Presigned URLs: the same dance in query params
+
+`aws s3 presign` moves everything into `X-Amz-*` query parameters. Verification
+differs in three ways:
+
+1. **The signature lives in `X-Amz-Signature`** — which must be stripped from
+   the canonical query before rebuilding it, while every _other_ `X-Amz-*`
+   param stays in.
+2. **The payload hash is always `UNSIGNED-PAYLOAD`** — the URL is minted before
+   any body exists.
+3. **Expiry is explicit.** `X-Amz-Expires` must be between 1 second and 7 days
+   (AWS's cap), and the request must land inside
+   `[X-Amz-Date, X-Amz-Date + expires]` — with the 15-minute skew allowance
+   applied only to the start, so a future-dated URL is tolerated but a lapsed
+   one is dead. Expired URLs get AWS's exact phrasing: `AccessDenied` with
+   "Request has expired".
+
+Since a presigned URL _is_ a bearer credential for its window, one non-obvious
+consequence: request logs. OpenBucket strips `X-Amz-Signature`,
+`X-Amz-Credential`, and `X-Amz-Security-Token` from every logged URL, so a
+leaked log file isn't a pile of replayable requests.
+
+## Why grind through all this?
+
+Because SigV4 _is_ the compatibility bar. "S3-compatible" doesn't mean "has
+buckets and objects" — it means the unmodified AWS SDK, aws-cli, and every
+S3-speaking tool can sign a request and have it verify, including the weird
+corners: unicode keys, duplicate query params, chunked streams, presigned
+expiry. Our unit tests cross-check the verifier against the `aws4` signing
+library and reproduce the AWS-published GET-Object reference signature
+byte-for-byte, and a separate conformance suite (`apps/conformance/`) plus
+e2e tests drive the real SDK and CLI against a running instance — the only
+proof that actually counts.
+
+If you're evaluating an S3-compatible store, the supported surface is
+documented honestly in the [S3 compatibility
+reference](/docs/reference/s3-compatibility), and the full protocol design —
+routing, XML envelopes, the error taxonomy around all of the above — is in the
+[whitepaper chapter on S3 & SigV4](/docs/whitepaper/02-s3-protocol-and-sigv4).
+For the friendlier face of presigning, see [sharing
+files](/docs/guides/sharing-files).
+
+---
+
+Building in this space too, or spotted a SigV4 corner we missed? Tell us in
+[Discussions](https://github.com/ProjectBay/openbucket/discussions) — and if
+this deep-dive was worth your scroll, a star on
+[github.com/ProjectBay/openbucket](https://github.com/ProjectBay/openbucket)
+helps the project reach the next person debugging `SignatureDoesNotMatch` at
+midnight.

--- a/apps/docs/blog/2026-09-02-one-click-deploys.md
+++ b/apps/docs/blog/2026-09-02-one-click-deploys.md
@@ -1,0 +1,196 @@
+---
+slug: one-click-deploys
+title: 'Your own S3, deployed in minutes: one-click templates for Render, Fly, Coolify & CapRover'
+description: Deploy a self-hosted, S3-compatible object store in minutes with one-click templates for Render, Fly.io, Coolify, and CapRover — just pick an admin password.
+authors: [openbucket]
+tags: [deployment, self-hosted, s3, render, fly, coolify]
+date: 2026-09-02
+keywords:
+  [
+    deploy s3 compatible storage,
+    self-hosted s3 render.com,
+    coolify object storage,
+    fly.io s3 storage,
+    caprover one click apps,
+    self-hosted object storage,
+    minio alternative,
+  ]
+draft: true
+---
+
+There's a gap between "this project looks interesting" and "I have a running
+instance with a URL I can point an SDK at" — and for most self-hosted software,
+that gap is an evening of YAML. We wanted OpenBucket's gap to be a coffee break.
+
+So the repo now ships **one-click / one-file deploy templates** for four popular
+platforms — [Render](https://render.com), [Fly.io](https://fly.io),
+[Coolify](https://coolify.io), and [CapRover](https://caprover.com) — under
+[`deploy/`](https://github.com/ProjectBay/openbucket/tree/main/deploy). Each one
+runs the standalone `ghcr.io/projectbay/openbucket` image, provisions a
+persistent volume at `/data`, and generates the random secrets for you. The only
+decision left is your admin password.
+
+<!-- truncate -->
+
+## Why "one-click" used to be impossible
+
+OpenBucket refuses to boot with weak or missing secrets — that's a feature. But
+until v0.1.0-alpha.19, one of those required values was `ADMIN_PASSWORD_HASH`:
+a pre-computed **argon2id hash** of your admin password. You had to run
+`npx @openbucket/nestjs hash 'your-password'` locally and paste the result into
+the platform's env config. That's fine for a `.env` file; it's fatal for a
+one-click flow, where the platform fills in values for you and there's no
+terminal in sight.
+
+Alpha.19 fixed this with a plaintext **`ADMIN_PASSWORD`** variable. The
+semantics are deliberately narrow:
+
+- OpenBucket **argon2id-hashes it on first boot** and seeds the admin user once
+  — the plaintext is never stored and never logged.
+- `ADMIN_PASSWORD_HASH` **still takes precedence** if you set it — handy when
+  you'd rather not have the plaintext in the platform's environment at all.
+
+That one change made every template below possible: platforms that can generate
+random values can now provision a complete, working instance.
+
+## What every template sets up
+
+All four templates share the same shape:
+
+- The pinned image `ghcr.io/projectbay/openbucket:0.1.0-alpha.20` (we're
+  pre-1.0, so there's no `latest` tag to lean on — pinning is the point).
+- A **persistent volume mounted at `/data`** (`DATA_DIR=/data`). This is where
+  the SQLite metadata *and* every blob live. No volume, no data after a
+  redeploy — this is the one thing you should double-check on any platform.
+- Port **9000**, serving the S3 API, the admin API, and the admin console from
+  one process. The platform terminates TLS in front of it.
+- Auto-generated `JWT_SECRET` and `ROOT_SECRET_ACCESS_KEY`. The
+  `ROOT_ACCESS_KEY_ID` defaults to `AKIAOPENBUCKETROOT01` — like an AWS access
+  key ID, it's an identifier, not a secret, so a shared default is fine
+  (override it if you like).
+
+When it's up, `https://<your-app-url>/admin` is the admin console and the root
+URL is your S3 endpoint (path-style addressing).
+
+## Render
+
+Add [`deploy/render/render.yaml`](https://github.com/ProjectBay/openbucket/blob/main/deploy/render/render.yaml)
+to a repo as `render.yaml` and create a **Blueprint**. Render generates the
+admin password, `JWT_SECRET`, and `ROOT_SECRET_ACCESS_KEY` (`generateValue: true`),
+and provisions a **10 GB persistent disk** at `/data`. You provide: nothing,
+strictly — but copy the generated `ADMIN_PASSWORD` from the dashboard to log in
+(or replace it with your own), and it's worth verifying the generated
+`JWT_SECRET` came out at 32+ characters, since OpenBucket will refuse to boot
+otherwise.
+
+## Fly.io
+
+Fly is the one template that isn't a web form — it's four commands with
+[`deploy/fly/fly.toml`](https://github.com/ProjectBay/openbucket/blob/main/deploy/fly/fly.toml):
+
+```bash
+fly launch --copy-config --no-deploy          # import the config
+fly volumes create openbucket_data --size 10  # persistent storage at /data
+fly secrets set \
+  ADMIN_PASSWORD='choose-a-strong-admin-password' \
+  JWT_SECRET="$(openssl rand -hex 32)" \
+  ROOT_SECRET_ACCESS_KEY="$(openssl rand -hex 32)"
+fly deploy
+```
+
+Note the explicit `fly volumes create` — on Fly, the volume is your job, and
+the config mounts it at `/data`. The template also sets
+`auto_stop_machines = false` and `min_machines_running = 1`, because an object
+store that scales to zero mid-upload is not a good time.
+
+## Coolify
+
+**New Resource → Docker Compose**, paste
+[`deploy/coolify/docker-compose.yaml`](https://github.com/ProjectBay/openbucket/blob/main/deploy/coolify/docker-compose.yaml),
+assign a domain (Coolify routes it to port 9000), deploy. Coolify's magic
+`SERVICE_PASSWORD_*` variables generate all three secrets — including the admin
+password, which lands in the service's **Environment Variables** as
+`SERVICE_PASSWORD_ADMIN`. Copy it to log in, or edit the admin password value
+there to pick your own. Data persists in the named `openbucket-data` volume,
+and the compose file wires a healthcheck against `/api/admin/health` so Coolify
+knows when the instance is actually ready.
+
+## CapRover — the full follow-along
+
+CapRover's template is the most complete of the four — a proper one-click app
+with a form, generated defaults, and post-deploy instructions — so let's walk
+it end to end.
+
+1. In the CapRover dashboard, go to **Apps → One-Click Apps/Databases** and
+   paste this raw URL at the bottom (or paste the YAML itself):
+
+   ```
+   https://raw.githubusercontent.com/ProjectBay/openbucket/main/deploy/caprover/openbucket.yml
+   ```
+
+2. Fill in the form. Only one field actually needs you:
+
+   - **Admin password** — your choice, minimum 8 characters. This is the
+     plaintext `ADMIN_PASSWORD` from earlier: hashed on first boot, never
+     stored.
+   - Everything else is pre-filled: image tag (`0.1.0-alpha.20`), admin
+     username (`admin`), region (`us-east-1`), access key ID
+     (`AKIAOPENBUCKETROOT01`), and randomly generated values for `JWT_SECRET`
+     and `ROOT_SECRET_ACCESS_KEY`.
+
+3. Deploy. CapRover creates a per-app volume mounted at `/data`, so your
+   objects survive restarts and app updates.
+
+4. You land on two URLs:
+
+   - **Admin console** — `https://<app>.<your-root-domain>/admin`. Sign in with
+     `admin` and the password you chose; you'll see the dashboard, bucket
+     browser, and settings.
+   - **S3 endpoint** — `https://<app>.<your-root-domain>` (path-style).
+
+5. Last step: open the app's **App Configs** tab and copy
+   `ROOT_SECRET_ACCESS_KEY` — that's the credential your S3 clients will use.
+
+## Day 2: point an SDK at it
+
+Your new instance speaks the S3 wire protocol, so the client side is the
+standard AWS SDK — just three settings that matter: your endpoint, path-style
+addressing, and the root credentials.
+
+```ts
+import { S3Client } from '@aws-sdk/client-s3';
+
+const s3 = new S3Client({
+  endpoint: 'https://openbucket.your-domain.example',
+  region: 'us-east-1',
+  forcePathStyle: true, // required — virtual-host addressing is not supported
+  credentials: {
+    accessKeyId: 'AKIAOPENBUCKETROOT01',
+    secretAccessKey: '<the generated ROOT_SECRET_ACCESS_KEY>',
+  },
+});
+```
+
+Two things worth doing before you put anything important in it:
+
+- **Harden it.** Don't hand the root credential to every app — mint scoped
+  access keys, review the exposed surface, and check the checklist in
+  [Securing OpenBucket](/docs/guides/securing-openbucket).
+- **Back it up.** OpenBucket is single-node by design; that `/data` volume is
+  the whole instance. Turn on scheduled snapshots (and, ideally, replication to
+  an external S3 target) — see
+  [Backup & restore](/docs/guides/backup-and-restore).
+
+The step-by-step platform docs live at
+[One-click deploy](/docs/operations/one-click-deploy), and if you're still
+deciding whether a single-node store fits your workload,
+[Is OpenBucket for you?](/docs/is-openbucket-for-you) gives you the honest
+answer.
+
+---
+
+Deployed one? We'd love to hear which platform and how it went — tell us in
+[Discussions](https://github.com/ProjectBay/openbucket/discussions). And if the
+template saved you an evening of YAML, a star on
+[GitHub](https://github.com/ProjectBay/openbucket) is how the next person finds
+it.

--- a/apps/docs/blog/2026-09-09-object-events-and-webhooks.md
+++ b/apps/docs/blog/2026-09-09-object-events-and-webhooks.md
@@ -1,0 +1,234 @@
+---
+slug: object-events-and-signed-webhooks
+title: 'Reacting to uploads: in-process object events and signed webhooks'
+description: Run code the moment a file lands in your self-hosted S3 store — @OnObjectCreated handlers in-process, or signed webhooks you actually verify.
+authors: [openbucket]
+tags: [nestjs, webhooks, events, s3, self-hosted, tutorial]
+date: 2026-09-09
+draft: true
+keywords:
+  [
+    s3 event notifications self-hosted,
+    nestjs object storage events,
+    webhook signature verification nodejs,
+    s3 object created event,
+    hmac webhook verification node,
+    transactional outbox webhooks,
+  ]
+---
+
+An upload is rarely the end of the story. The moment a file lands you usually want
+something to happen next: generate a thumbnail, index a document, kick off a virus
+scan, ping another service. On AWS that's S3 Event Notifications plus SNS or
+Lambda; self-hosted, you're often left polling a bucket on a cron.
+
+OpenBucket ships both halves of the answer. If your code runs **in the same NestJS
+process** as the store, a decorator gives you the event with zero configuration. If
+the consumer is a **separate service**, signed HTTP webhooks deliver the same event
+durably. In this post we'll build one feature — thumbnails for every uploaded
+image — both ways, including the part most webhook tutorials skip: actually
+verifying the signature on the receiving end.
+
+<!-- truncate -->
+
+## The event, first
+
+Both delivery paths carry the same flat, JSON-serializable `ObjectEvent`:
+
+```ts title="ObjectEvent (from @openbucket/nestjs)"
+interface ObjectEvent {
+  type: 'object.created' | 'object.deleted' | 'multipart.completed';
+  bucket: string;
+  key: string;
+  size: number; // bytes; 0 for a delete / delete-marker
+  etag: string; // object ETag; '' for a delete-marker
+  versionId?: string; // present only on versioning-enabled buckets
+  eventTime: string; // ISO-8601
+}
+```
+
+Three event types exist today, and only three: `object.created` (a committed
+`PutObject` / `CopyObject` / admin write), `object.deleted` (a delete or
+delete-marker), and `multipart.completed` (a committed
+`CompleteMultipartUpload`). Every field comes from the already-committed row —
+no request headers, IPs, or credentials are ever included. Note there's no
+content type in the event; if you need it, fetch it with `headObject`.
+
+## Act 1 — In-process: `@OnObjectCreated()`
+
+If OpenBucket is embedded in your NestJS app, you don't need HTTP at all.
+Decorate a provider method and it runs in your process whenever an object
+commits:
+
+```ts title="thumbnail.listener.ts"
+import { Injectable, Logger } from '@nestjs/common';
+import sharp from 'sharp';
+import {
+  OnObjectCreated,
+  OpenBucketService,
+  type ObjectEvent,
+} from '@openbucket/nestjs';
+
+@Injectable()
+export class ThumbnailListener {
+  private readonly log = new Logger(ThumbnailListener.name);
+
+  constructor(private readonly ob: OpenBucketService) {}
+
+  @OnObjectCreated()
+  async onCreated(event: ObjectEvent) {
+    // Only react to the uploads bucket — writing the thumbnail below fires
+    // another object.created, and this guard is what breaks the loop.
+    if (event.bucket !== 'uploads') return;
+
+    const head = await this.ob.headObject(event.bucket, event.key);
+    if (!head?.contentType?.startsWith('image/')) return;
+
+    const original = await this.ob.getObjectBuffer(event.bucket, event.key);
+    const thumb = await sharp(original).resize(320, 320, { fit: 'inside' }).webp().toBuffer();
+
+    await this.ob.putObject('thumbnails', `${event.key}.webp`, thumb, {
+      contentType: 'image/webp',
+    });
+    this.log.log(`thumbnail ready for ${event.bucket}/${event.key}`);
+  }
+}
+```
+
+Register `ThumbnailListener` as a provider and you're done. Two companion
+decorators cover the other events: `@OnObjectDeleted()` (perfect for cleaning up
+the matching thumbnail) and `@OnMultipartCompleted()`.
+
+Now the honest part. In-process handlers are dispatched **fire-and-forget** —
+OpenBucket never awaits them, so a handler that throws or hangs can't stall or
+fail the upload. The flip side: a handler failure is **logged and dropped, not
+retried**, and if your process crashes between the commit and your handler
+running, that event is gone. For anything you can't afford to lose, treat the
+handler as a cheap trigger — enqueue a job in BullMQ or your queue of choice —
+or use webhooks, which brings us to Act 2.
+
+## Act 2 — Standalone: signed HTTP webhooks
+
+Suppose thumbnail generation lives in a separate media service (or OpenBucket
+runs as the [standalone Docker container](/docs/getting-started/quickstart-docker)
+with no host app at all). Point OpenBucket at a URL:
+
+```ts title="app.module.ts (embedded)"
+OpenBucketModule.forRoot({
+  // …
+  webhooks: {
+    url: 'https://media.internal.example.com/hooks/openbucket',
+    secret: process.env.OB_WEBHOOK_SECRET!, // ≥ 32 chars, validated at boot
+    events: ['object.created'], // optional filter; default: all three
+  },
+});
+```
+
+Standalone, the same thing is env-driven: `WEBHOOK_URL`, `WEBHOOK_SECRET`, and
+an optional `WEBHOOK_EVENTS` CSV. Webhooks are **off** unless a URL is set, and
+the config is fail-closed: the URL must be `https` (or a loopback host) and the
+secret at least 32 characters, or the app refuses to boot.
+
+Delivery is built on a **transactional outbox**: each matching event persists a
+row in the *same transaction* that commits the object, so the notification
+commits atomically with the write — or not at all. A background runner drains
+the outbox and POSTs each event:
+
+```text title="What your endpoint receives"
+POST /hooks/openbucket
+Content-Type: application/json
+User-Agent: openbucket-webhooks/<version>
+X-OpenBucket-Event: object.created
+X-OpenBucket-Delivery: <uuid>
+X-OpenBucket-Signature: t=<unix>,v1=<hex-hmac>
+
+{"type":"object.created","bucket":"uploads","key":"2026/ab….jpg","size":12345,"etag":"…","eventTime":"2026-09-09T12:00:00.000Z"}
+```
+
+Only a `2xx` counts as success. Failures (non-`2xx`, network error, timeout —
+and any `3xx`, since redirects are deliberately not followed) retry with
+full-jitter exponential backoff, base 2 s, capped at 1 hour. After
+`maxAttempts` (default 8) the row is dead-lettered and no longer retried;
+terminal rows are pruned after 7 days. Delivery is **at-least-once** and
+ordering is best-effort due-time order, not strictly per-key — plan for both.
+
+### Verify the signature (don't skip this)
+
+An unverified webhook endpoint is an unauthenticated API: anyone who finds the
+URL can feed your media service fake "objects". The
+`X-OpenBucket-Signature` header is `t=<unix>,v1=<hex>`, where the HMAC-SHA256
+covers `` `${timestamp}.${rawBody}` `` — the same Stripe-style scheme you may
+already know. Verification needs the **raw** request bytes (parsing and
+re-serializing the JSON changes them and breaks the signature), a
+**constant-time** compare, and a staleness check against replay:
+
+```ts title="media-service: receiver with verification (Express)"
+import express from 'express';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const SECRET = process.env.OB_WEBHOOK_SECRET!;
+
+function verify(rawBody: string, header: string, secret: string): boolean {
+  const parts = Object.fromEntries(header.split(',').map((p) => p.split('=')));
+  const t = Number(parts['t']);
+  if (!Number.isFinite(t) || Math.abs(Date.now() / 1000 - t) > 300) return false; // 5-min window
+  const expected = createHmac('sha256', secret).update(`${t}.${rawBody}`).digest('hex');
+  const a = Buffer.from(expected);
+  const b = Buffer.from(parts['v1'] ?? '');
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+const app = express();
+
+// express.raw, NOT express.json — the signature covers the unparsed bytes.
+app.post('/hooks/openbucket', express.raw({ type: 'application/json' }), (req, res) => {
+  const raw = req.body.toString('utf8');
+  const sig = req.header('X-OpenBucket-Signature') ?? '';
+  if (!verify(raw, sig, SECRET)) return res.status(401).end();
+
+  const deliveryId = req.header('X-OpenBucket-Delivery')!;
+  const event = JSON.parse(raw);
+  // At-least-once delivery → dedupe on deliveryId, then enqueue the thumbnail job.
+  enqueueThumbnailJob(deliveryId, event);
+
+  res.status(204).end(); // respond fast; do the work async
+});
+```
+
+Two receiver rules worth tattooing somewhere: **dedupe on
+`X-OpenBucket-Delivery`** (a crash after your `2xx` but before the row is marked
+delivered will re-send), and **return `2xx` quickly** — do the actual resizing
+off the request path so a slow `sharp` call doesn't eat into the 5-second
+delivery timeout and trigger a pointless retry.
+
+## Choosing between the two
+
+Same event, two contracts:
+
+| | In-process handlers | Signed webhooks |
+| --- | --- | --- |
+| Runs | Same Node process | Any external HTTPS URL |
+| Setup | Register a provider | `webhooks.url` + secret |
+| Delivery | Fire-and-forget, no retry | Durable outbox, at-least-once, retried |
+| Failure mode | Logged and dropped | Backoff → dead-letter after `maxAttempts` |
+
+A reasonable default: reach for the **in-process handler** when the work is
+cheap, local, and tolerable to lose in a crash — or when it just enqueues into a
+queue you already trust. Reach for **webhooks** when the consumer is another
+service, or when "we never got the event" is not an acceptable bug report. And
+they're not exclusive: run both, one for local jobs and one to notify the
+outside world.
+
+The full option list and edge cases live in the
+[events and webhooks guide](/docs/guides/events-and-webhooks), the upload paths
+that fire `object.created` are covered in [file uploads](/docs/guides/file-uploads),
+and every `webhooks.*` knob is in the
+[NestJS module reference](/docs/reference/nestjs-module).
+
+---
+
+OpenBucket is pre-1.0 and built in the open — if signed, self-hosted S3 event
+notifications are something you've been missing, a ⭐ on
+[GitHub](https://github.com/ProjectBay/openbucket) tells us to keep going. Found
+a sharp edge in the webhook contract, or want an event we don't emit yet? Open a
+thread in [Discussions](https://github.com/ProjectBay/openbucket/discussions).

--- a/apps/docs/blog/2026-09-16-s3-in-integration-tests.md
+++ b/apps/docs/blog/2026-09-16-s3-in-integration-tests.md
@@ -1,0 +1,272 @@
+---
+slug: stop-mocking-s3-in-integration-tests
+title: 'Stop mocking S3: real object storage in your integration tests'
+description: Mocking the S3 client tests your mocks, not your code. Boot a real S3-compatible store in-process in Jest — or in a testcontainer — with zero infra.
+authors: [openbucket]
+tags: [testing, jest, s3, nestjs, testcontainers, ci]
+date: 2026-09-16
+draft: true
+keywords:
+  [
+    mock s3 jest,
+    s3 integration testing nodejs,
+    localstack alternative,
+    testcontainers s3,
+    nestjs testing file upload,
+    jest s3 integration test,
+  ]
+---
+
+If your test suite stubs out `S3Client`, here's an uncomfortable question: what
+exactly is it testing? A mocked `send()` happily accepts a presigned URL that
+would never verify, a content type that would never survive a round-trip, and a
+multipart upload sequence that no real S3 implementation would accept. The mock
+asserts that you *called* S3 the way you expected to — not that S3 would have
+said yes.
+
+The usual fix is to run something real in CI — LocalStack, MinIO — and eat the
+infra cost. OpenBucket offers a cheaper path: it's an S3-compatible object store
+that ships as an npm package, so in a Node/NestJS project you can boot the
+**real wire protocol inside your Jest process**. No container, no AWS account,
+no network. This post shows both flavors: in-process for Nest apps, and a
+testcontainer for everything else.
+
+<!-- truncate -->
+
+## What mocks can't catch
+
+These are the failure modes that only surface against a real implementation:
+
+- **Signatures.** SigV4 signing (headers *and* presigned query strings) depends
+  on the exact canonical request. A mock never verifies a signature; a real
+  server rejects a subtly wrong one with `403 SignatureDoesNotMatch`.
+- **Content types and metadata.** Does `ContentType` actually round-trip? Do
+  your `x-amz-meta-*` headers come back on GET? A mock returns whatever you
+  told it to return.
+- **Multipart uploads.** Part ordering, minimum part sizes, complete/abort
+  semantics — an entire state machine that a stub reduces to "resolves".
+- **Error envelopes.** Real S3 errors are XML with a `<Code>` that the SDK maps
+  to an error name like `NoSuchKey`. If your retry/fallback logic branches on
+  those names, a mocked rejection proves nothing.
+
+Unit tests with a mocked client are still fine for pure business logic. But the
+storage *integration* — the part that actually breaks in production — needs a
+real implementation on the other side of the socket.
+
+## Flavor 1: in-process, for NestJS apps
+
+`@openbucket/nestjs` is a Nest module, so it boots inside
+`Test.createTestingModule` like any other module — the same way OpenBucket's
+own wire-level specs run. Omitting the `admin` block gives you a headless,
+S3-only store: no admin API, no JWT setup, nothing to configure but a data
+directory and credentials.
+
+```bash
+npm install --save-dev @aws-sdk/client-s3
+npm install @openbucket/nestjs
+```
+
+The spec below boots the store on a random port, points the standard AWS SDK at
+it, and exercises the three things mocks can't: a signed round-trip, a
+presigned URL fetched with plain `fetch`, and a real error envelope.
+
+```ts title="s3-storage.integration.spec.ts"
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { OpenBucketModule, OpenBucketService } from '@openbucket/nestjs';
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { mkdtempSync, rmSync } from 'node:fs';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const CREDS = {
+  accessKeyId: 'AKIATESTONLY00000000',
+  secretAccessKey: 'test-only-secret-test-only-secret-40ch',
+};
+
+describe('object storage (real S3, in-process)', () => {
+  let app: INestApplication;
+  let ob: OpenBucketService;
+  let s3: S3Client;
+  let dataDir: string;
+  let origin: string;
+
+  beforeAll(async () => {
+    // A fresh temp dir per suite keeps parallel Jest workers isolated.
+    dataDir = mkdtempSync(join(tmpdir(), 'ob-spec-'));
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        OpenBucketModule.forRoot({
+          dataDir,
+          mountPath: '/s3',
+          rootCredentials: CREDS,
+          // no `admin` block → headless S3-only store, ideal for tests
+        }),
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+    await app.listen(0); // any free port
+    const { port } = app.getHttpServer().address() as AddressInfo;
+    origin = `http://127.0.0.1:${port}`;
+
+    ob = app.get(OpenBucketService);
+    await ob.createBucket('uploads');
+
+    s3 = new S3Client({
+      endpoint: `${origin}/s3`, // host + mountPath
+      region: 'us-east-1',
+      forcePathStyle: true, // required — path-style addressing
+      credentials: CREDS,
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('round-trips an object over the wire, content type intact', async () => {
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: 'uploads',
+        Key: 'hello.txt',
+        Body: 'hello world',
+        ContentType: 'text/plain',
+      }),
+    );
+    const got = await s3.send(new GetObjectCommand({ Bucket: 'uploads', Key: 'hello.txt' }));
+    expect(await got.Body!.transformToString()).toBe('hello world');
+    expect(got.ContentType).toBe('text/plain');
+  });
+
+  it('mints a presigned GET URL that a plain fetch can use', async () => {
+    const url = ob.presignGetUrl('uploads', 'hello.txt', {
+      baseUrl: origin, // scheme + host; the mountPath is appended for you
+      expiresIn: 60,
+    });
+    const res = await fetch(url); // unauthenticated client — the signature does the work
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('hello world');
+  });
+
+  it('returns a real S3 error envelope for a missing key', async () => {
+    await expect(
+      s3.send(new GetObjectCommand({ Bucket: 'uploads', Key: 'does-not-exist' })),
+    ).rejects.toMatchObject({ name: 'NoSuchKey' });
+  });
+});
+```
+
+Everything here is real: the SDK signs each request with SigV4 and the server
+verifies it; the presigned URL is checked cryptographically; the `NoSuchKey`
+error name comes from an actual XML error body the SDK parsed. Flip one
+character in the secret key and the suite fails with `403` — try doing *that*
+with a mock.
+
+Two practical notes. First, if your app uses the
+[`@openbucket/nestjs/multer` upload interceptor](/docs/guides/file-uploads),
+import your real `AppModule` (or feature module) instead of registering
+`OpenBucketModule` directly, and drive the endpoint with `supertest` — you're
+then testing your actual upload pipeline, validation included. Second, metadata
+lives in SQLite and blobs on disk under `dataDir`, so the `mkdtempSync` +
+`rmSync` pair above is the entire setup/teardown story.
+
+## Flavor 2: a testcontainer, for everything else
+
+Not on Nest? Polyglot stack? OpenBucket also ships as a Docker image, and this
+is exactly how the project tests itself: the S3 conformance suite boots the
+image with [testcontainers](https://testcontainers.com/) and points
+`@aws-sdk/client-s3` at the mapped port. Adapted for a published image:
+
+```ts title="s3.container-setup.ts"
+import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers';
+
+export async function startOpenBucket(): Promise<StartedTestContainer> {
+  return new GenericContainer('ghcr.io/projectbay/openbucket:0.1.0-alpha.20')
+    .withExposedPorts(9000)
+    .withEnvironment({
+      DATA_DIR: '/data',
+      JWT_SECRET: 'test-only-jwt-secret-test-only-jwt-secret',
+      ROOT_ACCESS_KEY_ID: 'AKIATESTONLY00000000',
+      ROOT_SECRET_ACCESS_KEY: 'test-only-secret-test-only-secret-40ch',
+      // Required by the refuse-to-boot config schema (argon2id format);
+      // a dummy is fine — tests never log in to the admin API.
+      ADMIN_PASSWORD_HASH: '$argon2id$v=19$m=65536,t=3,p=4$abc$def',
+    })
+    .withWaitStrategy(Wait.forHttp('/api/admin/health', 9000).forStatusCode(200))
+    .withStartupTimeout(60_000)
+    .start();
+}
+```
+
+Then construct the client from the mapped port:
+
+```ts title="s3.client.ts"
+const endpoint = `http://${container.getHost()}:${container.getMappedPort(9000)}`;
+const s3 = new S3Client({
+  endpoint,
+  region: 'us-east-1',
+  forcePathStyle: true,
+  credentials: {
+    accessKeyId: 'AKIATESTONLY00000000',
+    secretAccessKey: 'test-only-secret-test-only-secret-40ch',
+  },
+});
+```
+
+The image is small (one Node process, SQLite inside), boots to a healthy state
+in seconds, and needs no volumes for throwaway test data. Testcontainers has
+bindings for Java, Go, Python, .NET and more, so the same recipe works outside
+TypeScript.
+
+## What this means for CI
+
+- **No external service, no credentials.** Nothing to provision, no AWS
+  account, no secrets to rotate. The keys in your specs are throwaway strings.
+- **The in-process flavor doesn't even need Docker.** It's just Jest, so it
+  runs on any CI runner — and offline on the train.
+- **Deterministic isolation.** A temp `dataDir` per suite means no shared state
+  between workers and no cleanup jobs against a long-lived test bucket.
+
+## An honest comparison
+
+- **LocalStack** emulates a large slice of AWS. If your tests touch SQS, Lambda
+  *and* S3, it's the right tool. If you only need S3, you're running a hefty
+  container to get one API.
+- **Client mocks** (e.g. `aws-sdk-client-mock`) remain great for unit-testing
+  logic *around* storage. The argument here isn't "never mock" — it's that the
+  integration seam deserves a real implementation.
+- **MinIO in CI** gives you real S3 semantics too, and it scales far beyond
+  what OpenBucket targets. But it's always a separate process — there's no
+  in-process option for a Node test suite. (More in
+  [OpenBucket vs MinIO](/docs/comparisons/vs-minio).)
+
+And the honest caveat on our side: OpenBucket is pre-1.0 and deliberately
+single-node. Its S3 surface is broad — SigV4, presigned URLs, multipart,
+versioning, object lock, lifecycle, CORS, bucket policies — but it is not a
+byte-for-byte AWS clone. Check the
+[S3 compatibility matrix](/docs/reference/s3-compatibility) before you rely on
+an operation, and if production for you means real AWS S3, treat these tests as
+what they are: high-fidelity, not identical.
+
+## Where to go next
+
+- Embedding the module properly, `forRootAsync` and all →
+  [quickstart: embed in NestJS](/docs/getting-started/quickstart-embed)
+- The full `OpenBucketService` API you can call from specs →
+  [service reference](/docs/reference/openbucket-service)
+- Whether OpenBucket fits beyond the test suite →
+  [Is OpenBucket for you?](/docs/is-openbucket-for-you)
+
+---
+
+If you rip a mock out of your suite this week and something real breaks — that's
+the feature. Tell us about it in
+[Discussions](https://github.com/ProjectBay/openbucket/discussions), and if the
+in-process trick earns a place in your toolbox, a star on
+[GitHub](https://github.com/ProjectBay/openbucket) helps the next person who's
+still stubbing `send()`.

--- a/apps/docs/blog/2026-09-23-transactional-outbox-replication.md
+++ b/apps/docs/blog/2026-09-23-transactional-outbox-replication.md
@@ -1,0 +1,199 @@
+---
+slug: transactional-outbox-replication
+title: Replicating an object store with a transactional outbox
+description: How OpenBucket mirrors every PUT and DELETE to an S3 remote — same-transaction outbox rows, per-key ordering, coalescing, backoff, and dead-lettering.
+authors: [openbucket]
+tags: [replication, architecture, durability, s3, self-hosted, deep-dive]
+date: 2026-09-23
+keywords:
+  [
+    transactional outbox pattern,
+    s3 replication self-hosted,
+    object storage replication,
+    outbox pattern example,
+    exponential backoff dead letter,
+    replicate objects to s3,
+  ]
+draft: true
+---
+
+The transactional outbox is a well-worn pattern for messages: instead of
+publishing to a broker inside a request, you write an "intent" row in the same
+database transaction as your business data, and a background worker delivers it
+later. Atomic with the commit, durable across crashes, retried until done.
+
+OpenBucket applies the same pattern to something chunkier: **replicating blobs**.
+Every object mutation on a single-node store gets mirrored, asynchronously, to
+any S3-compatible remote — AWS S3, Cloudflare R2, Backblaze B2, a MinIO box in
+another rack. Blobs are not messages, though, and the differences (ordering,
+overwrites, multi-gigabyte payloads, hour-long remote outages) are exactly where
+the design gets interesting. This post walks the implementation as it ships.
+
+<!-- truncate -->
+
+## Why the naive version is broken
+
+The obvious implementation of "mirror every write" is a dual-write: commit the
+object locally, then call `PutObject` on the remote before returning.
+
+That has two failure modes, and both are bad. If the remote call is synchronous,
+every upload now pays a WAN round-trip and inherits the remote's availability —
+your local store is down whenever your mirror is. If you fire-and-forget instead,
+you get the classic lost-mirror-on-crash: the process dies between the local
+commit and the remote send, and that object is silently never replicated. No
+record that a send was ever owed, so nothing to retry. You find out when you need
+the mirror — which is the one moment it must not have holes.
+
+The fix is to make "this object owes the remote a send" a durable fact, written
+atomically with the object itself.
+
+## Enqueue in the same transaction
+
+OpenBucket's write path is a two-phase writer: the blob is staged and renamed
+into place on disk, then the metadata row is committed in SQLite. The replication
+intent is persisted **inside that same metadata transaction** — the enqueue seam
+joins the caller's open `EntityManager` rather than forking its own:
+
+```ts
+// object-writer.service.ts — inside the PUT transaction, before em.commit()
+this.outbox?.enqueue(em, {
+  bucket,
+  key: cmd.key,
+  op: 'PUT',
+  versionId: row.currentVersionId,
+  etag: row.etag,
+  size: row.size,
+  contentType: row.contentType,
+});
+
+await em.commit();
+```
+
+The same seam runs on multipart-upload completion and on the delete paths, which
+enqueue `op: 'DELETE'` intents on the delete's transaction. The consequence is
+the whole point of the pattern: the intent commits **if and only if** the write
+commits. A crash a microsecond after `em.commit()` loses nothing — the intent is
+already on disk. A rollback takes the intent with it, so the outbox never
+describes an object that doesn't exist.
+
+The enqueue itself is synchronous and does no I/O beyond one extra INSERT on the
+hot path — and when replication is disabled it's a no-op, so a local-only
+deployment pays nothing.
+
+## The drain worker, and what "durable" buys you
+
+A background runner ticks every 5 seconds (`OPENBUCKET_REPLICATION_DRAIN_INTERVAL_MS`)
+and asks one bounded question: which distinct `(bucket, key)` pairs have a due
+pending intent? It takes up to 50 keys per tick (`OPENBUCKET_REPLICATION_BATCH_KEYS`),
+oldest first, and drains them in parallel — distinct keys are independent, so
+cross-key fan-out is safe, and the batch size also bounds how many file
+descriptors and sockets are ever in flight at once.
+
+Because intents live in the database, **boot resume is free**. There is no
+in-memory queue to reconstruct and no "inflight" state to recover: the first tick
+after a restart simply picks up every due pending row. A crash mid-send leaves
+the intent pending, and it's retried — which is safe because both operations are
+idempotent: a PUT converges the remote key to the same bytes, and a DELETE that
+finds the remote key already gone counts as success.
+
+For large payloads the worker streams: objects above a 64 MiB threshold
+(`OPENBUCKET_REPLICATION_LARGE_OBJECT_THRESHOLD_BYTES`) go to the remote as a
+multipart upload rather than a single PUT.
+
+## Per-key ordering, not global ordering
+
+Message-outbox implementations often chase total ordering. For blob replication
+that's unnecessary — whether `a.jpg` or `b.jpg` mirrors first is irrelevant —
+but **per-key** ordering is essential. If a client PUTs a key and then DELETEs
+it, replaying those in the wrong order resurrects a deleted object on the remote.
+
+OpenBucket gets per-key order from two cheap pieces. The write path already
+serializes same-key writes behind a per-key lock, so a key's intents are enqueued
+in write order; a process-monotonic sequence number (derived from the wall clock,
+bumped on collision — no autoincrement round-trip) makes that order durable. The
+worker then reads a key's pending chain strictly in sequence order, while
+different keys proceed in parallel. Order where it matters, concurrency
+everywhere else.
+
+## Coalescing: only the last write matters
+
+Here's where blobs diverge from messages for real. A message queue must deliver
+every message. A mirror only has to converge on the **current** state — if a key
+was overwritten five times while the remote was slow, replaying all five PUTs is
+pure waste, potentially gigabytes of it.
+
+So the worker coalesces with last-writer-wins semantics: it loads the key's
+pending chain, acts only on the **last** intent, and marks every earlier one as
+superseded up front. `PUT, PUT, PUT` collapses to one PUT of the latest bytes;
+`PUT, DELETE` collapses to one DELETE. One edge case falls out naturally: if the
+worker picks up a PUT intent whose object has since been deleted locally, the
+send is a no-op success — the DELETE intent behind it in the chain carries the
+real state. Once the send succeeds, the superseded rows are deleted so the outbox
+table stays small.
+
+The enqueue side stays deliberately dumb — it always appends, never dedupes.
+Coalescing is entirely the reader's job, which keeps the write path at exactly
+one INSERT.
+
+## Backoff, dead-lettering, and the multi-hour outage
+
+Failures back off exponentially with full jitter:
+`min(1s × 2^(attempts−1), 5min) × rand(0.5..1.5)` — real constants from the
+runner (`BACKOFF_BASE_MS = 1_000`, `BACKOFF_CAP_MS = 5 × 60_000`). After
+`OPENBUCKET_REPLICATION_MAX_ATTEMPTS` failures (default **12**), an intent
+dead-letters to `failed` and stops retrying, so one un-replicable object can't
+occupy the worker forever.
+
+It's worth doing the honest arithmetic on that: twelve attempts at those backoffs
+give an intent roughly 10–30 minutes of retry budget (jitter-dependent). During a
+**multi-hour** remote outage, then, the store itself is fine — writes keep
+landing locally and keep enqueueing durable intents — but intents born early in
+the outage will exhaust their attempts and dead-letter. Nothing is lost: they sit
+visibly in `failed`, and when the remote returns, the admin **Reconcile** action
+diffs local objects against the target and re-enqueues whatever is missing, as a
+single-flight, bounded backfill. If your remote is routinely flaky for hours,
+raising the attempts cap buys a longer window; reconcile is the backstop either
+way.
+
+## Watching it work
+
+Replication you can't observe is replication you don't trust. The read model
+aggregates the outbox with a single GROUP BY — it never materializes the queue —
+and surfaces it in three places:
+
+- the admin console's **Replication** page (depth, lag, last error, per-bucket
+  breakdown, and the Reconcile button),
+- `GET /api/admin/replication/status`, and
+- the CLI: `openbucket replication status` prints enabled/pending/inflight/failed
+  counters, the age of the oldest pending intent, the last error, and a
+  per-bucket table (`--json` for scripts).
+
+"Inflight" here means pending intents that have been attempted at least once —
+i.e. currently in a backoff cycle. The Prometheus endpoint also exports outbox
+depth, so you can alert on a growing backlog; see the
+[observability guide](/docs/guides/observability). One deliberate redaction rule
+throughout: the remote endpoint and credentials never appear in status output,
+job errors, or the audit log.
+
+## What this is not
+
+Worth saying plainly: this is **disaster-recovery-grade mirroring, not high
+availability**. Replication is asynchronous and one-way, so your RPO is nonzero —
+whatever is in the outbox when the disk dies hasn't reached the remote yet.
+There is no failover: the remote is a durable copy you'd restore from, not a
+standby that starts serving traffic, and not a read replica. OpenBucket stays a
+single-node, single-writer store by design; if you need multi-node quorum
+storage, this isn't that, and we'd rather tell you so.
+
+What it does answer is the first question every self-hoster asks about a
+single-node object store — *what happens when the disk dies?* — with: your
+objects are on real S3, at most seconds to minutes behind. Setup is a handful of
+env vars; the [replication and tiering guide](/docs/guides/replication-and-tiering)
+has the copy-paste version, plus the cold-tiering half of the story.
+
+---
+
+If you enjoy this kind of design writeup, a ⭐ on
+[GitHub](https://github.com/ProjectBay/openbucket) is the best way to tell us to
+write more of them. Poking holes in the failure-mode analysis is even better —
+[Discussions](https://github.com/ProjectBay/openbucket/discussions) is open.

--- a/apps/docs/blog/2026-09-30-admin-console-tour.md
+++ b/apps/docs/blog/2026-09-30-admin-console-tour.md
@@ -1,0 +1,172 @@
+---
+slug: admin-console-tour
+title: "What's in the box: a tour of the OpenBucket admin console"
+description: A walkthrough of the admin console that ships inside OpenBucket — dashboard, object browser, search, config editors, keys, users, backups, and audit log.
+authors: [openbucket]
+tags: [admin-console, s3, self-hosted, object-storage, web-ui]
+date: 2026-09-30
+draft: true
+keywords:
+  [
+    s3 admin ui self-hosted,
+    minio console alternative,
+    object storage web ui,
+    s3 bucket browser,
+    self-hosted s3 gui,
+    s3 compatible admin console,
+  ]
+---
+
+Most self-hosted object stores treat the web UI as an afterthought: a thin bucket
+list bolted on later, a separate container to deploy, or a "community" console
+that lags three versions behind the server. You end up doing real administration
+with `aws s3api` and a prayer.
+
+OpenBucket takes the opposite bet. The Angular admin console ships **inside the
+same npm package and container as the store itself** — no second deployment, no
+version skew, nothing extra to run. Set `serveUi: true` and it's there, whether
+you run OpenBucket standalone via Docker or embedded under a path prefix in your
+own NestJS app. This post is the tour: every screen, in the order you'll actually
+use them.
+
+<!-- truncate -->
+
+## Zero extra deployment
+
+Before the tour, the part that shapes everything else: the console is served as
+static assets by the store, under your mount path.
+
+```text
+Standalone:  http://localhost:9000/admin
+Embedded:    http://<host><mountPath>/admin     (e.g. /storage/admin)
+```
+
+The same build works identically in both modes, and it's an opt-in: configure the
+`admin` block with `serveUi: true` and the console is wired; leave `admin` out
+entirely and you get a headless, S3-only store with no admin surface at all. The
+details live in the [NestJS module reference](/docs/reference/nestjs-module).
+Behind login (argon2id passwords, rotating JWTs), every feature screen is
+lazy-loaded, so first paint stays fast.
+
+## The dashboard
+
+Sign in and you land on an at-a-glance overview: total buckets, objects, and
+stored bytes, your most recent buckets, and quick actions.
+
+![OpenBucket admin dashboard](/img/admin_dashboard.png)
+
+Below the headline numbers sit the **usage-analytics charts** — storage over
+time, a per-bucket size breakdown, and request/error rates — fed by a background
+rollup with bounded retention. The page polls on a bounded interval and pauses
+while the tab is hidden, so it stays live without hammering your server.
+
+## Buckets and the object browser
+
+**Buckets** lists every bucket with object count, size, versioning, and lock
+status. The **object browser** inside each bucket lists with a `/` delimiter, so
+shared prefixes surface as folders you can walk into. From there:
+
+- **Upload** files by drag-and-drop or picker, and **download** them back.
+- **Preview** objects inline — images, PDFs, text and code, video, and audio —
+  rendered in a sandboxed frame (CSP-locked, with per-kind size caps), so a
+  hostile upload can't script its way out of the preview pane.
+- **Share** an object with a presigned link that expires.
+- **Delete** objects; on a versioned bucket you can inspect versions and delete
+  markers instead of just the latest.
+
+Rows are keyboard-operable, so you can drive the whole browser without a mouse.
+
+## Cross-bucket search
+
+Once you have more than a handful of buckets, "which bucket was that in again?"
+becomes a daily question. **Search** answers it across *every* bucket at once:
+pick `prefix` or `contains` mode, optionally filter by bucket or tag, and each
+hit deep-links straight to that object's folder in the browser. The query box is
+debounced and results page via a keyset cursor, so it stays snappy on large
+stores.
+
+## Per-bucket configuration editors
+
+The bucket detail page is a tabbed editor for everything you'd otherwise script
+against the S3 API:
+
+- **Versioning** — enable or suspend.
+- **Encryption** — toggle SSE-S3 at-rest encryption (AES-256).
+- **Object Lock** — governance/compliance retention and legal hold.
+- **Lifecycle** — expiration and transition (tiering) rules.
+- **CORS** — the cross-origin rule editor.
+- **Policy** — the bucket policy JSON editor.
+- **Tags** and **Properties** round it out.
+
+These aren't read-only status pages; they're the actual write path for bucket
+config, which matters when you're debugging a CORS rule at 11 pm and don't want
+to hand-craft XML.
+
+## Settings: keys, users, backups, and more
+
+Everything instance-level is consolidated into one tabbed **Settings** page —
+and because the active tab is a `?tab=` query param, you can bookmark or link a
+specific tab.
+
+![Settings](/img/admin_settings.png)
+
+**Access Keys.** Create, inspect, rotate, and revoke keys — including **scoped
+sub-keys** confined to a bucket or prefix, which is how you hand a tenant or a
+CI job credentials that can't touch anything else. The secret is shown once on
+creation, and scoped keys get an effective-permissions allow/deny view plus a
+single-action simulator so you can check "can this key do X?" before it ships.
+
+**Admin Users.** Multiple admin accounts, each either a **full admin** or
+**read-only** (signs in, sees everything, gets a `403` on any change). Guardrails
+are built in: you can't delete or demote the last full admin, and you can't
+delete your own account.
+
+**Backup & Restore.** Whole-instance or per-bucket `.zip` snapshots, on demand
+or on a **schedule** (cron or interval) with retention. Restore resets the
+target, so the console demands explicit confirmation first. More in the
+[backup & restore guide](/docs/guides/backup-and-restore).
+
+**Replication.** If you mirror to an external S3-compatible target, this tab
+shows outbox depth and lag, plus a **Reconcile** action that diffs local objects
+against the remote and re-enqueues anything missing.
+
+**Integrity.** The background scrubber that re-hashes blobs against their stored
+SHA-256 reports here: scanned/ok/corrupt/repaired stat cards, a corrupt-object
+table, and a **Scrub now** button. When anything is corrupt, a red badge appears
+in the sidebar — hidden at zero, so it only speaks up when it matters.
+
+**Audit Log.** A durable, queryable record of every state-changing admin action,
+newest first, keyset-paged with bounded retention. Not a tail of stdout — it's
+persisted and searchable from the console.
+
+## The quality-of-life layer
+
+Small things that add up: the console is localized in **English and German**,
+supports **light/dark/system** themes with a color-scheme picker, and lets you
+change your password without leaving the Appearance tab.
+
+## The honest caveats
+
+OpenBucket is pre-1.0. The S3 surface and the console are feature-complete and
+tested, but APIs may still shift before 1.0, and the store is single-node by
+design — if you need a distributed cluster, this isn't it, and the
+[Is OpenBucket for you?](/docs/is-openbucket-for-you) guide says so plainly.
+Coming from MinIO and wondering how the consoles compare? There's an honest
+[comparison](/docs/comparisons/vs-minio) for that too.
+
+## Try it in two minutes
+
+The fastest way to see all of this is the
+[Docker quickstart](/docs/getting-started/quickstart-docker) — one container,
+console included at `/admin`. The full
+[admin console guide](/docs/guides/admin-console) covers every screen in more
+depth.
+
+---
+
+If a bundled console is the thing you've been missing from self-hosted object
+storage, consider dropping a ⭐ on
+[GitHub](https://github.com/ProjectBay/openbucket) — it's the main way new
+people discover the project. And if there's a screen you wish existed, tell us
+in [Discussions](https://github.com/ProjectBay/openbucket/discussions); the
+roadmap is genuinely shaped there.

--- a/apps/docs/blog/2026-10-07-detecting-bit-rot.md
+++ b/apps/docs/blog/2026-10-07-detecting-bit-rot.md
@@ -1,0 +1,180 @@
+---
+slug: detecting-bit-rot
+title: Detecting bit rot before your users do
+description: How OpenBucket's background scrubber catches silent disk corruption — SHA-256 at write time, byte-budgeted re-hashing, and digest-verified self-repair.
+authors: [openbucket]
+tags: [bit-rot, data-integrity, durability, s3, self-hosted, engineering]
+date: 2026-10-07
+draft: true
+keywords:
+  [
+    detect bit rot,
+    silent data corruption,
+    object storage integrity check,
+    sha256 checksum verification,
+    data scrubbing,
+    self-hosted s3 durability,
+    self healing storage,
+  ]
+---
+
+Here's an uncomfortable question for anyone running storage: **when was the last
+time your system re-read a file it wrote a year ago?** For most setups the honest
+answer is *never*. Bytes go in, sit on a disk for months, and the first entity to
+read them back is the user who needs them — which means the user is also your
+corruption detector. By then the file has probably aged out of every backup you
+keep.
+
+This post is an engineering deep-dive into how OpenBucket's background integrity
+scrubber works: recording a SHA-256 for every object at write time, re-hashing
+blobs in the background without starving live traffic, and — when a replica
+exists — repairing corruption automatically. Even if you never run OpenBucket,
+the design constraints generalize to whatever storage you do run.
+
+<!-- truncate -->
+
+## "The disk will tell me" is false comfort
+
+Bit rot is the slow, silent corruption of data at rest — a flipped bit from a
+failing sector, a firmware bug, a bad cable, a botched RAID rebuild. The
+dangerous cases are precisely the ones nothing reports: the drive returns bytes
+it believes are fine, and they aren't.
+
+Filesystems mostly won't save you here. The common production defaults on Linux
+checksum their own **metadata**, not your file contents — a silently corrupted
+data block in a blob is returned to the application without complaint.
+Filesystems that do checksum data end-to-end (ZFS, Btrfs) exist, but most
+deployments — and nearly every Docker volume, VPS disk, and homelab — don't run
+them. If the storage layer can't vouch for your bytes, the application layer has
+to.
+
+## Design: hash on write, re-hash forever
+
+OpenBucket computes and stores a whole-object **SHA-256 over the plaintext
+bytes** (`contentSha256`) for every object at write time — before any SSE-S3
+encryption, so one digest validates single-part and multipart objects alike.
+That digest already backs a read-time gate: a full `GET` re-hashes the blob as
+it streams and returns a `500` on mismatch rather than serve corrupted bytes.
+
+But the read gate only protects objects somebody reads. The
+**background scrubber** closes the gap: on a scheduled tick it walks current,
+local objects in keyset-paginated batches, streams each blob through the *same*
+verifier the read gate uses (decrypting SSE-S3 first, so it's always hashing
+plaintext), and compares the result to the stored digest. Sharing one verifier
+is deliberate — two hashing implementations would eventually drift, and a
+scrubber that computes a different digest than the write path is a false-alarm
+generator.
+
+## Throttling is the hard part
+
+Writing a loop that re-hashes every file is an afternoon of work. Writing one
+you can run **next to production traffic** is the actual engineering problem: a
+naive scrubber saturates disk I/O re-reading terabytes, and your p99 latency
+pays for it.
+
+OpenBucket's scrubber is throttled on three axes, straight from the code:
+
+- **A per-tick object cap** (`OPENBUCKET_INTEGRITY_SCRUB_MAX_OBJECTS_PER_TICK`,
+  default 1,000) bounds the work per tick regardless of blob sizes.
+- **A per-tick byte budget** (`OPENBUCKET_INTEGRITY_SCRUB_MAX_BYTES_PER_TICK`,
+  default 1 GiB) bounds disk-read amplification — the verifier reports exactly
+  how many plaintext bytes it hashed, and the tick is charged for them. The
+  budget is checked *before* hashing each object; the moment either limit is
+  hit, the tick stops and persists a durable resume cursor, so the next tick
+  (default: every 60 seconds) picks up exactly where this one left off — across
+  restarts too.
+- **A `setImmediate` yield between batches**, so request handlers interleave
+  with the scan instead of waiting behind it, and a scheduler guard that skips
+  a tick rather than let slow ones pile up.
+
+One more throttle worth calling out: the scrubber is **off by default**. A
+fresh install performs zero extra disk reads and zero extra DB writes until you
+opt in with `OPENBUCKET_INTEGRITY_SCRUB_ENABLED=true`. Background I/O you didn't
+ask for is a bug, not a feature.
+
+Robustness details matter as much as budgets. The cursor always advances even
+when a single object errors, so one poisoned key can't wedge the whole walk. A
+blob deleted mid-scan (`ENOENT`) is left `unchecked`, never flagged `corrupt`.
+And a digest mismatch triggers a re-read of the object's *current* stored hash
+first — if the object was overwritten mid-walk, that's a stale comparison, not
+corruption.
+
+## Verdicts you can actually see
+
+Every scrubbed object carries a verdict: `unchecked` → `ok` or `corrupt`, with
+a timestamp and a bounded, URL-redacted diagnostic. The admin console's
+**Integrity** page (with a corrupt-count badge in the sidebar) and the
+`/api/admin/integrity` API expose:
+
+- `GET /api/admin/integrity/status` — enabled flag, lifetime scanned/repaired
+  counters, live ok/corrupt/unchecked counts, last-run time, and the resume
+  cursor,
+- `GET /api/admin/integrity/corrupt` — the paginated corrupt-object list,
+- `POST /api/admin/integrity/scrub` — a manual "scrub now" trigger that runs a
+  one-shot pass on the next tick (even when the schedule is disabled) but never
+  bypasses the budgets.
+
+For alerting, two Prometheus gauges do the job:
+`openbucket_integrity_objects{status="corrupt"}` above zero should page
+someone, and a stale `openbucket_integrity_last_run_timestamp` means the
+scrubber stopped making progress. See the
+[observability guide](/docs/guides/observability) for the full metrics table.
+
+## Self-healing — with a paranoid ordering
+
+Detection alone leaves you with a list of broken files. When a
+[replication target](/docs/guides/replication-and-tiering) is configured
+(OpenBucket asynchronously mirrors every committed write to an S3-compatible
+remote), a `corrupt` verdict triggers repair — and the ordering here is the
+whole point:
+
+1. **Fetch the remote copy first.** A missing remote key fails the repair
+   without ever touching the local blob.
+2. **Hard-link the corrupt local blob aside** as a zero-copy backup before any
+   rewrite.
+3. **Stage the remote bytes through the same two-phase writer** as every normal
+   PUT — write to a temp file, `fsync`, atomic `rename` — with a size cap
+   against a divergent remote object, re-encrypting to the original SSE form.
+4. **Re-read the just-written on-disk bytes and verify them against the stored
+   SHA-256 before the repair is accepted.** Only a digest match commits the
+   repair and flips the row back to `ok`.
+
+If that final check fails — the remote copy is *also* bad — the hard-linked
+original is restored and the row stays `corrupt`. Why so paranoid? Because a
+repair path that trusts its source can make things worse: replication is
+asynchronous, remotes can diverge, and remote bytes can rot too. Verifying the
+digest before committing the swap guarantees repair is monotonic — it can fix a
+blob or leave it exactly as found, never replace recoverable-maybe bytes with
+confidently wrong ones.
+
+## And when there's no replica?
+
+Then you get **detection and alerting only** — the row is marked `corrupt`, the
+metric fires, and restoring the object from a
+[backup snapshot](/docs/guides/backup-and-restore) is on you. That's an honest
+limitation, not a footnote: OpenBucket is pre-1.0, single-node by design, and a
+scrubber cannot conjure good bytes from a disk that lost them. What it buys you
+is *time* — you find out while last month's backup still has the file, instead
+of a year later when it doesn't.
+
+All the knobs live in the [configuration reference](/docs/reference/configuration),
+and the [durability page](/docs/concepts/durability) covers how scrubbing fits
+next to atomic writes, replication, and backups.
+
+## Scrub whatever you run
+
+The transferable lesson has nothing to do with OpenBucket: **storage you never
+re-read is storage you're merely hoping about.** If your stack records checksums
+(S3 checksums, ZFS, a `sha256` column next to your uploads), schedule something
+that actually verifies them. If it doesn't, even a nightly cron that re-hashes a
+rotating slice of files against a manifest beats nothing — you'll find rot while
+your backups still cover it. Just throttle it: budget the bytes, persist a
+cursor, and never let the janitor outrun the tenants.
+
+---
+
+If you're the kind of person who reads to the end of a post about re-hashing
+files, we'd love to have you around — a ⭐ on
+[GitHub](https://github.com/ProjectBay/openbucket) helps more than you'd think,
+and if you've fought bit rot in production, tell us the war story in
+[Discussions](https://github.com/ProjectBay/openbucket/discussions).

--- a/apps/docs/blog/2026-10-14-what-it-takes-to-call-a-data-store-1-0.md
+++ b/apps/docs/blog/2026-10-14-what-it-takes-to-call-a-data-store-1-0.md
@@ -1,0 +1,176 @@
+---
+slug: what-it-takes-to-call-a-data-store-1-0
+title: What it takes to call a data store 1.0
+description: For a data store, 1.0 is two promises — a stable API and safe data — and both demand evidence. OpenBucket's exit bar, published so you can hold us to it.
+authors: [openbucket]
+tags: [release-engineering, reliability, s3, self-hosted, open-source]
+date: 2026-10-14
+keywords:
+  [
+    when to release 1.0 open source,
+    semantic versioning data store,
+    s3 compatible object storage stability,
+    backup restore testing strategy,
+    software release readiness checklist,
+    api stability policy,
+  ]
+draft: true
+---
+
+For most software, 1.0 is a marketing decision. Bump the number when the landing
+page looks good, when a conference is coming up, when the team needs a morale win.
+Nobody gets hurt: if a to-do app breaks an API, users grumble and update a few call
+sites.
+
+A data store doesn't get that luxury. When you tag 1.0 on something that holds
+other people's bytes, you are making exactly two promises: **the API is stable
+enough to build on** (real semver from here on), and **your data is safe with
+us**. Both promises are cheap to make and expensive to keep — which is why neither
+should be backed by confidence. They should be backed by evidence. This post is
+OpenBucket's public definition of that evidence: the exit bar we have to clear
+before `v1.0.0` exists, published so anyone can hold us to it.
+
+<!-- truncate -->
+
+## Confidence is not evidence
+
+Every maintainer *feels* ready before they *are* ready. We shipped the full S3
+surface — versioning, object lock, multipart, lifecycle, encryption, bucket
+policies — months ago, and it's tested. By vibes alone, OpenBucket could have been
+"1.0" in the summer.
+
+But "the tests pass" and "the feature list is long" are statements about effort,
+not about the two promises. Evidence for promise one looks like a reviewed, frozen
+surface under a written policy. Evidence for promise two looks like a restore
+drill that actually ran, on a populated instance, and either passed or told you
+something ugly. (Ours told us something ugly. More on that below.)
+
+So here is the bar, item by item — partly as a status report, partly because these
+are principles any project shipping a data store could steal.
+
+## The exit bar
+
+### 1. A reviewed, frozen public surface — under a written policy
+
+Semver only means something if you've decided what the "public API" *is*. Before
+freezing, every export gets an API-review pass: the `OpenBucketService` facade,
+the `OpenBucketModule` options, the `/multer` adapter, the admin JSON API and its
+generated client. Naming, defaults, and types that would be painful to change
+post-freeze get settled now, and the result ships with a written semver and
+deprecation policy — a document, not a vibe.
+
+The prep work is underway and visible in the changelog: composition-root
+internals moved out of the package root into a `/standalone` subpath so the main
+entry only exposes what we intend to support; three near-identical upload-result
+types were unified onto one shape; and the standalone env vars were consolidated
+onto a single `OPENBUCKET_` prefix — a deliberately breaking rename we made *now*
+because pre-1.0 is the last cheap moment to fix inconsistent names. The freeze
+itself has not happened yet, for a reason covered at the end of this post.
+
+### 2. A release gate that runs the full suite — no flaky-skips
+
+Every project accumulates a quiet shame: the specs that are skipped in CI because
+they're "flaky." Ours were the concurrency and blob-store specs — exactly the
+tests you most want passing in an object store. For a while the npm release
+workflow skipped the unit suite around them.
+
+That's fixed: the quarantined concurrency, request-id, and scheduled-backup specs
+were de-flaked, and the release gate now runs the **full** unit suite. The
+remaining piece is surfacing and enforcing a coverage threshold (CI already
+collects coverage; the number needs to become a gate). The principle: **the
+release you tag 1.0 must pass its own complete test suite.** If a test is too
+flaky to run, it's too flaky to trust — fix it or admit the feature isn't done.
+
+### 3. A machine-generated conformance report, not a hand-maintained table
+
+Hand-maintained compatibility tables rot the day after they're written. Since
+alpha.19, the S3 conformance suite emits a **machine-generated, dated report** —
+client × operation — which feeds the
+[S3 compatibility reference](/docs/reference/s3-compatibility). If the AWS CLI,
+the JS SDK, or boto3 stops working against some operation, the report says so
+with a date on it, rather than a table quietly claiming last quarter's truth.
+
+### 4. A restore drill you actually ran — and what ours caught
+
+This is the item that turns "your data is safe" from a slogan into evidence: an
+automated **backup → upgrade → restore** drill over a populated instance, plus a
+declared-stable on-disk format and a disaster-recovery runbook.
+
+We ran the drill (backup a loaded instance, restore into a fresh one, diff
+everything), and it earned its keep immediately: the v1 backup manifest was
+**silently dropping prior object versions, per-bucket default encryption,
+lifecycle rules, CORS, and bucket policies**. Worst of all, restored objects in
+encrypted buckets came back *unencrypted at rest* — a silent security downgrade
+no unit test had flagged. Manifest v2 (alpha.20) fixes all of it: full version
+history is replayed in order, and per-bucket config is applied *before* object
+bytes are written, so restores re-encrypt under the new instance's key. Old v1
+archives still restore.
+
+The lesson generalizes: **a backup you haven't restored is a hypothesis.** The
+formal on-disk-format declaration and the published DR runbook are still ahead of
+us; the drill that justifies them already exists and lives in CI. Details in the
+[backup & restore guide](/docs/guides/backup-and-restore).
+
+### 5. A security re-pass of everything added since the last audit
+
+OpenBucket went through an external white-box audit in July 2026 — 22 confirmed
+findings, all remediated in alpha.8 (the write-up is
+[public](/docs/concepts/security-audit-2026)). But an audit is a snapshot, and
+we've shipped a lot since: async replication and tiering (remote credentials,
+SSRF surface), scoped-key policy evaluation, presigned POST, and the new
+plaintext `ADMIN_PASSWORD` seed path. Before 1.0, that post-audit surface gets a
+focused security re-pass, and the threat model (STRIDE) — deferred from the
+original audit — gets published. A 2026 audit badge doesn't cover 2026's code
+unless someone re-checks the delta.
+
+### 6. Honest numbers and honest expectations
+
+Two documents remain that are less glamorous than any feature: **single-node
+benchmarks** (PUT/GET throughput at a few object sizes, with stated hardware and
+methodology — answering "is one node fast enough for me?") and a **production
+checklist** (TLS proxy in front, backups on, replication target configured,
+resource limits). They complement the existing
+[Is OpenBucket for you?](/docs/is-openbucket-for-you) page, which already says
+plainly that this is a single-node store by design and points you elsewhere when
+that's wrong for you. Numbers you'd rather not publish are exactly the ones a
+1.0 owes its users.
+
+### 7. The classic trap: freezing an API nobody has run in anger
+
+Here's the item that gates everything else, and the reason this post isn't a 1.0
+announcement. The most common premature-1.0 mistake isn't a missing test — it's
+**freezing an API that only its authors have used**. Internal usage cannot tell
+you which option name is confusing, which default is wrong, or which method
+shape you'll regret, because the authors unconsciously route around every rough
+edge.
+
+So the API freeze — the one irreversible step — is explicitly gated on a handful
+of real deployments exercising the surface first. Everything else (correctness,
+durability, benchmarks) proceeds in parallel; the freeze waits for evidence only
+strangers can generate. If you're running OpenBucket today, your bug reports and
+"this option name confused me" comments are, quite literally, on the critical
+path to 1.0.
+
+## Where that leaves us
+
+Done: the de-flaked full-suite release gate, the machine-generated conformance
+report, the restore fidelity drill (and the manifest-v2 fix it forced), and the
+freeze-prep API cleanup. Remaining: the coverage gate, the written semver policy
+and the freeze itself, the format declaration and DR runbook, the security
+re-pass and threat model, benchmarks, and the production checklist. The
+up-to-date version of this list lives on the [roadmap](/docs/roadmap).
+
+We're publishing the bar before clearing it on purpose. A checklist you grade
+yourself on privately is worth little; one your users can quote back at you is a
+commitment device. If we tag `v1.0.0` with any of the above missing, call it out
+— publicly. And if you maintain a data store of your own, steal the bar. Adjust
+the items, keep the principle: **1.0 is not a feeling. It's evidence.**
+
+---
+
+If you want to hold us to this, the best seats are a ⭐ on
+[GitHub](https://github.com/ProjectBay/openbucket) — where the release gate,
+conformance report, and restore drill are all public — and
+[Discussions](https://github.com/ProjectBay/openbucket/discussions), where the
+1.0 checklist gets argued about in the open. Running OpenBucket in a real
+deployment? Tell us what the API got wrong *before* we freeze it.


### PR DESCRIPTION
## What's in here

14 blog posts on a weekly publishing schedule. **Only the first goes live on merge** — the other 13 carry `draft: true` (Docusaurus excludes drafts from production builds). To publish each one on its date, flip its `draft` flag (each flip = tiny PR = auto docs deploy).

| Publish date | Post | Type |
|---|---|---|
| 2026-07-16 | Our backups were lying to us (restore-drill post-mortem) | **live on merge** |
| 2026-07-22 | Direct browser uploads with presigned POST | tutorial |
| 2026-07-29 | OpenBucket vs MinIO | comparison |
| 2026-08-05 | SQLite + the filesystem is a perfectly good object store | deep-dive |
| 2026-08-12 | Keep your S3 SDK, swap the endpoint | conversion |
| 2026-08-19 | Build your own Cloudinary-lite (image transforms) | tutorial |
| 2026-08-26 | AWS Signature V4 from scratch | deep-dive |
| 2026-09-02 | One-click deploys (Render/Fly/Coolify/CapRover) | conversion |
| 2026-09-09 | Object events and signed webhooks | tutorial |
| 2026-09-16 | Stop mocking S3 in integration tests | conversion |
| 2026-09-23 | Transactional-outbox replication | deep-dive |
| 2026-09-30 | Admin console tour | conversion |
| 2026-10-07 | Detecting bit rot before your users do | deep-dive |
| 2026-10-14 | What it takes to call a data store 1.0 | essay |

## Verification

- Every post was written against the actual source (`libs/nestjs`), docs guides, deploy templates, e2e/conformance specs, and changelog — including real constants (backoff caps, scrub budgets, skew windows) pulled from code.
- All internal `/docs/*` links checked against existing pages; images limited to the two real console screenshots.
- `npm run build` passes (one pre-existing whitepaper minifier warning, unrelated).

## Review notes

- Skim for tone/claims you don't want public — the post-mortem (07-16) and the vs-MinIO comparison are the most sensitive.
- Dates/cadence are a proposal; shuffle freely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)